### PR TITLE
[#61] Ajustado cache first nas listas

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -30,10 +30,10 @@ module.exports = {
     'no-console': 'warn',
     'no-unused-vars': 'error',
     'object-curly-spacing': ['error', 'always'],
-    semi: 'warn',
+    semi: 'error',
     'react/display-name': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
-    '@typescript-eslint/no-non-null-assertion': 'off'
+    '@typescript-eslint/no-non-null-assertion': 'off',
   },
   overrides: [
     {

--- a/src/store/product-list/__tests__/sagas-server.test.ts
+++ b/src/store/product-list/__tests__/sagas-server.test.ts
@@ -3,7 +3,7 @@
 import { authSelectors } from '@store/auth';
 import { extractObjectElement } from '@utils/filters';
 import { call, select } from 'redux-saga/effects';
-import { productListModels, productListSelectors } from '..';
+import { productListModels } from '..';
 import * as sagaServer from '../sagas-server';
 import { appProductListFormater, dbProductListFormated } from '../utils';
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
@@ -56,9 +56,6 @@ describe('ProductList Sagas Server', () => {
         const gen = sagaServer.getProductLists();
 
         expect(gen.next().value).toEqual(select(authSelectors.isAnonymously));
-        expect(gen.next().value).toEqual(
-          select(productListSelectors.getProductLists),
-        );
         expect(gen.next().value).toEqual(select(authSelectors.getUserId));
 
         const userId = '1234' as any;
@@ -84,11 +81,8 @@ describe('ProductList Sagas Server', () => {
         const gen = sagaServer.getProductLists();
 
         expect(gen.next().value).toEqual(select(authSelectors.isAnonymously));
-        expect(gen.next(true).value).toEqual(
-          select(productListSelectors.getProductLists),
-        );
 
-        expect(gen.next().done).toBe(true);
+        expect(gen.next(true).done).toBe(true);
       });
     });
 

--- a/src/store/product-list/__tests__/selectors.test.ts
+++ b/src/store/product-list/__tests__/selectors.test.ts
@@ -2,6 +2,7 @@
 import { productListSelectors } from '..';
 import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
 import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
 
 describe('ProductList Selector', () => {
   test('deve obter o state do productListReducer', () => {
@@ -33,5 +34,24 @@ describe('ProductList Selector', () => {
     const response = productListSelectors.isLoading(mockState);
 
     expect(response).toEqual(false);
+  });
+
+  test('deve obter os itens de um productList', () => {
+    const mockedListItem = new ProductItemBuilderMock()
+      .withId('12345')
+      .withName('mock name')
+      .build();
+    const mockedList = new ProductListBuilderMock()
+      .withId(2)
+      .withItems([mockedListItem])
+      .build();
+
+    const mockState = new AppStateMockBuilder()
+      .withProductList({ productLists: [mockedList] })
+      .build();
+
+    const response = productListSelectors.getProductItems(mockState, 2);
+
+    expect(response).toEqual([mockedListItem]);
   });
 });

--- a/src/store/product-list/sagas-server.ts
+++ b/src/store/product-list/sagas-server.ts
@@ -2,7 +2,7 @@ import { select, call } from 'redux-saga/effects';
 import { authSelectors } from '@store/auth';
 import { ProductItem, ProductList, ProductLists } from './types';
 import { extractObjectElement } from '@utils/filters';
-import { productListModels, productListSelectors } from '.';
+import { productListModels } from '.';
 import { QueryFirestore } from './models';
 import { appProductListFormater, dbProductListFormated } from './utils';
 
@@ -23,8 +23,7 @@ export function* createProductList(productList: ProductList) {
 
 export function* getProductLists() {
   const isAnonymously = yield select(authSelectors.isAnonymously);
-  const productLists = yield select(productListSelectors.getProductLists);
-  if (isAnonymously) return productLists;
+  if (isAnonymously) return;
 
   const userId: string = yield select(authSelectors.getUserId);
   if (userId) {
@@ -88,7 +87,7 @@ export function* createProductItem(productItem: ProductItem, listId: string) {
 
 export function* getProductItems(listId: string) {
   const isAnonymously = yield select(authSelectors.isAnonymously);
-  if (isAnonymously) return [];
+  if (isAnonymously) return;
 
   const userId = yield select(authSelectors.getUserId);
 

--- a/src/store/product-list/selectors.ts
+++ b/src/store/product-list/selectors.ts
@@ -5,9 +5,14 @@ const getState = (state: RootState) => state.productListReducer;
 const getProductLists = (state: RootState) =>
   state.productListReducer.productLists;
 
+const getProductItems = (state: RootState, listId: string) =>
+  state.productListReducer.productLists.find((list) => list.id === listId)
+    ?.items;
+
 const isLoading = (state: RootState) => state.productListReducer.isLoading;
 
 const selectors = {
+  getProductItems,
   getState,
   getProductLists,
   isLoading,


### PR DESCRIPTION
Foi feito um ajuste na saga do ProductList para que seja usado primeiramente os dados do servidor, caso não consiga usar o do servidor, é usado o local, isso pode ocasionar problema de perca de sincronização caso local esteja mais atualizado que o remoto, mas isso está planejado de ser corrigido na #32. Closes #61 