### PR TITLE
[#68] Organizado imports por grupo ascendentemente

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,12 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: 'module',
   },
-  plugins: ['react', 'typescript', '@typescript-eslint'],
+  plugins: [
+    'react',
+    'typescript',
+    '@typescript-eslint',
+    'eslint-plugin-import-helpers',
+  ],
   rules: {
     // disable the rule for all files
     '@typescript-eslint/explicit-function-return-type': 'off',
@@ -34,6 +39,14 @@ module.exports = {
     'react/display-name': 'off',
     '@typescript-eslint/ban-ts-ignore': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
+    'import-helpers/order-imports': [
+      'error',
+      {
+        newlinesBetween: 'always',
+        groups: ['module', '/^@(components|locales|routes|navigator|styles|store|utils|models|lib|assets|errors)|src/', ['parent', 'sibling', 'index']],
+        alphabetize: { order: 'asc', ignoreCase: true },
+      },
+    ],
   },
   overrides: [
     {

--- a/App.tsx
+++ b/App.tsx
@@ -1,11 +1,12 @@
 import * as React from 'react';
-import AppNavigator from '@navigator';
-import { Provider } from 'react-redux';
-import createStore from '@store';
 import RNBootSplash from 'react-native-bootsplash';
-import Banner from '@components/banner';
-import firebaseInit from 'src/firebase';
 import { Provider as PaperProvider } from 'react-native-paper';
+import { Provider } from 'react-redux';
+
+import Banner from '@components/banner';
+import AppNavigator from '@navigator';
+import createStore from '@store';
+import firebaseInit from 'src/firebase';
 import theme from 'src/styles/theme';
 
 const { store } = createStore();

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,4 @@ Caso algum desses requisitos não seja cumprido o PR será imediatamente reprova
 - Apenas 1 commit por PR
 - Commit seguindo o padrão "[#ISSUE_ID] Descricao do commit", por exemplo: "[#49] Edited Readme"
 - Tudo, exceto os textos, deve estar escrito em inglês
+- Imports precisam estar organizado em grupos e cada grupo em ordem alfabética, seguindo o padrão do projeto

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
 import 'react-native-gesture-handler';
 import { AppRegistry } from 'react-native';
+import PushNotification from 'react-native-push-notification';
+
 import App from './App';
 import { name as appName } from './app.json';
-import PushNotification from 'react-native-push-notification';
 
 PushNotification.configure({
   popInitialNotification: true,

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "babel-jest": "^24.9.0",
     "babel-plugin-module-resolver": "^4.0.0",
     "eslint": "^6.5.1",
+    "eslint-plugin-import-helpers": "^1.1.0",
     "eslint-plugin-react": "^7.20.0",
     "eslint-plugin-typescript": "^0.14.0",
     "husky": "^4.2.5",

--- a/src/components/admob-banner/index.tsx
+++ b/src/components/admob-banner/index.tsx
@@ -1,7 +1,6 @@
 // @ts-nocheck
-import React from 'react';
-
 import { BannerAd, TestIds, BannerAdSize } from '@react-native-firebase/admob';
+import React from 'react';
 import Config from 'react-native-config';
 
 const AdmobBanner = () => {

--- a/src/components/banner/__tests__/useBanner.test.ts
+++ b/src/components/banner/__tests__/useBanner.test.ts
@@ -1,8 +1,10 @@
-import * as reactRedux from 'react-redux';
 import { act, renderHook } from '@testing-library/react-hooks';
-import useBanner from '../useBanner';
-import { notificationActions, notificationSelector } from '@store/notification';
+import * as reactRedux from 'react-redux';
+
 import appLocale from '@locales';
+import { notificationActions, notificationSelector } from '@store/notification';
+
+import useBanner from '../useBanner';
 
 const strings = appLocale();
 

--- a/src/components/banner/index.tsx
+++ b/src/components/banner/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import useBanner from './useBanner';
-import { Container } from './styles';
 import { Banner as PaperBanner } from 'react-native-paper';
+
+import { Container } from './styles';
+import useBanner from './useBanner';
 
 const Banner = () => {
   const { body, icon, isVisible, bannerActions } = useBanner();

--- a/src/components/banner/useBanner.ts
+++ b/src/components/banner/useBanner.ts
@@ -1,7 +1,8 @@
-import { useSelector, useDispatch } from 'react-redux';
-import { notificationSelector, notificationActions } from '@store/notification';
 import { useEffect, useState, useCallback } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
 import appLocale from '@locales';
+import { notificationSelector, notificationActions } from '@store/notification';
 import { BannerButton } from '@store/notification/types';
 
 const strings = appLocale();

--- a/src/components/datetimepicker/index.tsx
+++ b/src/components/datetimepicker/index.tsx
@@ -1,5 +1,6 @@
-import React from 'react';
 import NativeDateTimePicker from '@react-native-community/datetimepicker';
+import React from 'react';
+
 import useDateTimePicker from './useDateTimePicker';
 
 type DateMode = 'date' | 'time' | 'datetime' | 'countdown' | undefined;

--- a/src/components/datetimepicker/useDateTimePicker.ts
+++ b/src/components/datetimepicker/useDateTimePicker.ts
@@ -1,5 +1,6 @@
 import { Event } from '@react-native-community/datetimepicker';
-import { Props } from '.';
+
+import { Props } from './';
 
 const useDateTimePicker = (props: Props) => {
   const handleChange = (event: Event, newDate?: Date) => {

--- a/src/components/dialog/index.tsx
+++ b/src/components/dialog/index.tsx
@@ -1,9 +1,10 @@
-import Button from '@components/button';
-import Paragraph from '@components/paragraph';
-import appLocale from '@locales';
 import React from 'react';
 import { ScrollView } from 'react-native';
 import { Dialog as PaperDialog } from 'react-native-paper';
+
+import Button from '@components/button';
+import Paragraph from '@components/paragraph';
+import appLocale from '@locales';
 
 const strings = appLocale();
 

--- a/src/components/divider/index.tsx
+++ b/src/components/divider/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Divider as PaperDivider } from 'react-native-paper';
+
 import { Container } from './styles';
 
 interface Props {

--- a/src/components/divider/styles.ts
+++ b/src/components/divider/styles.ts
@@ -1,5 +1,6 @@
-import { dimensions, getStyleAsNumber } from '@styles';
 import styled from 'styled-components/native';
+
+import { dimensions, getStyleAsNumber } from '@styles';
 
 interface ContainerProps {
   rowDivider?: boolean;

--- a/src/components/fullscreen-loader/index.tsx
+++ b/src/components/fullscreen-loader/index.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { ActivityIndicator as PaperActivityIndicator } from 'react-native-paper';
+
 import { Container } from './styles';
 
 const FullscreenLoader = () => {

--- a/src/components/fullscreen-loader/styles.ts
+++ b/src/components/fullscreen-loader/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 
 const Container = styled.View`

--- a/src/components/header/__tests__/useHeader.test.ts
+++ b/src/components/header/__tests__/useHeader.test.ts
@@ -1,10 +1,12 @@
-import { act, renderHook } from '@testing-library/react-hooks';
-import useHeader from '../useHeader';
-import { StatusBar } from 'react-native';
 import * as navigation from '@react-navigation/native';
+import { act, renderHook } from '@testing-library/react-hooks';
+import { StatusBar } from 'react-native';
 import * as paper from 'react-native-paper';
+
 import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
 import { useThemeMocks } from 'src/__tests__/paper-mocks';
+
+import useHeader from '../useHeader';
 
 jest.mock('@react-navigation/native');
 jest.mock('react-native-paper');

--- a/src/components/header/index.tsx
+++ b/src/components/header/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { StatusBar } from 'react-native';
 import { Appbar as PaperAppBar } from 'react-native-paper';
+
 import useHeader from './useHeader';
 
 export interface Props {

--- a/src/components/header/useHeader.ts
+++ b/src/components/header/useHeader.ts
@@ -1,8 +1,8 @@
-import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { DrawerNavigationProp } from '@react-navigation/drawer';
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { useCallback, useEffect, useState } from 'react';
-import { useTheme } from 'react-native-paper';
 import { StatusBar } from 'react-native';
+import { useTheme } from 'react-native-paper';
 
 type NavProps = NavigationProp<{}> & DrawerNavigationProp<{}>;
 

--- a/src/components/icon/__tests__/useIcon.test.ts
+++ b/src/components/icon/__tests__/useIcon.test.ts
@@ -1,6 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import useIcon from '../useIcon';
 import { Animated } from 'react-native';
+
+import useIcon from '../useIcon';
 
 describe('Testando useIcon', () => {
   const initialProps = {

--- a/src/components/icon/index.tsx
+++ b/src/components/icon/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import { ViewStyle } from 'react-native';
+import { IconButton as PaperIconButton } from 'react-native-paper';
+
 import { IconContainer } from './styles';
 import useIcon from './useIcon';
-import { IconButton as PaperIconButton } from 'react-native-paper';
 
 export interface Props {
   isVisible: boolean;

--- a/src/components/icon/styles.ts
+++ b/src/components/icon/styles.ts
@@ -1,5 +1,5 @@
-import styled from 'styled-components/native';
 import { Animated } from 'react-native';
+import styled from 'styled-components/native';
 
 export const KeyboardAvoidingView = styled.KeyboardAvoidingView``;
 

--- a/src/components/icon/useIcon.ts
+++ b/src/components/icon/useIcon.ts
@@ -1,7 +1,9 @@
-import { Props } from '.';
-import { Animated } from 'react-native';
 import { useState, useEffect, useCallback } from 'react';
+import { Animated } from 'react-native';
+
 import { animation } from '@styles';
+
+import { Props } from './';
 
 const useIcon = (props: Props) => {
   const { isVisible, onPress, useAnimation } = props;

--- a/src/components/list/__tests__/useList.test.ts
+++ b/src/components/list/__tests__/useList.test.ts
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react-hooks';
+
+import { Props } from '../';
 import useList from '../useList';
-import { Props } from '..';
 
 describe('testando useList', () => {
   test('ao receber uma lista de selectedItems, deve retornar um data informando quais os elementos estão selecionados', () => {

--- a/src/components/list/components/list-left/index.tsx
+++ b/src/components/list/components/list-left/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { ListCheckMode } from '../..';
 import { List as PaperList } from 'react-native-paper';
+
+import { ListCheckMode } from '../../';
 
 interface Props {
   leftProps: {

--- a/src/components/list/components/list-right/index.tsx
+++ b/src/components/list/components/list-right/index.tsx
@@ -1,7 +1,8 @@
+import React from 'react';
+
 import Icon from '@components/icon';
 import { RightIcon } from '@components/list';
 import { dimensions, getStyleAsNumber } from '@styles';
-import React from 'react';
 
 interface Props {
   rightProps: {

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { List as PaperList } from 'react-native-paper';
+
 import ListLeft from './components/list-left';
 import ListRight from './components/list-right';
 import useList from './useList';

--- a/src/components/list/useList.ts
+++ b/src/components/list/useList.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
-import { PaperListData, Props } from '.';
+
+import { PaperListData, Props } from './';
 
 const useList = (props: Props) => {
   const [data, setData] = useState(props.data);

--- a/src/components/menu/__tests__/useMenu.test.ts
+++ b/src/components/menu/__tests__/useMenu.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
+
 import useMenu from '../useMenu';
 
 describe('useMenu', () => {

--- a/src/components/menu/index.tsx
+++ b/src/components/menu/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { TouchableWithoutFeedback } from 'react-native-gesture-handler';
 import { Divider, Menu as PaperMenu } from 'react-native-paper';
+
 import { ItemsContainer } from './styles';
 import useMenu from './useMenu';
 

--- a/src/components/product-item/__tests__/useProductItem.test.ts
+++ b/src/components/product-item/__tests__/useProductItem.test.ts
@@ -1,5 +1,7 @@
-import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
 import { renderHook } from '@testing-library/react-hooks';
+
+import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+
 import useProductItem from '../useProductItem';
 
 describe('useProductItem', () => {

--- a/src/components/product-item/index.tsx
+++ b/src/components/product-item/index.tsx
@@ -1,5 +1,9 @@
 import React from 'react';
 
+import Divider from '@components/divider';
+import Icon from '@components/icon';
+import Menu from '@components/menu';
+import appLocale, { appCurrency } from '@locales';
 import { ProductItem } from '@store/product-list/types';
 
 import {
@@ -16,11 +20,8 @@ import {
   Title,
   TopContainer,
 } from './styles';
-import Divider from '@components/divider';
-import Icon from '@components/icon';
 import useProductItem from './useProductItem';
-import appLocale, { appCurrency } from '@locales';
-import Menu from '@components/menu';
+
 export interface Props {
   onPress?: () => void;
   index: number;

--- a/src/components/product-item/styles.ts
+++ b/src/components/product-item/styles.ts
@@ -1,7 +1,8 @@
 import styled from 'styled-components/native';
-import { colors, dimensions } from '@styles';
+
 import NativeTitle from '@components/subheading';
 import NativeText from '@components/text';
+import { colors, dimensions } from '@styles';
 import theme from 'src/styles/theme';
 
 export const ItemButton = styled.TouchableOpacity`

--- a/src/components/product-item/useProductItem.ts
+++ b/src/components/product-item/useProductItem.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import { Props } from '.';
+
+import { Props } from './';
 
 const useProductItem = (props: Props) => {
   const { productItem } = props;

--- a/src/components/surface/index.tsx
+++ b/src/components/surface/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { ScrollView, ViewStyle } from 'react-native';
-
 import { Surface as PaperSurface } from 'react-native-paper';
 
 interface Props {

--- a/src/components/text-input/__tests__/useTextInput.test.ts
+++ b/src/components/text-input/__tests__/useTextInput.test.ts
@@ -1,4 +1,5 @@
 import { renderHook, act } from '@testing-library/react-hooks';
+
 import useTextInput from '../useTextInput';
 
 describe('Testando useTextInput', () => {

--- a/src/components/text-input/index.tsx
+++ b/src/components/text-input/index.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Container } from './styles';
+import { KeyboardType, ViewStyle, TextInputProps } from 'react-native';
+import { TextInput as PaperTextInput } from 'react-native-paper';
 
 import HelperComponent from '@components/helper-text';
-import { KeyboardType, ViewStyle, TextInputProps } from 'react-native';
 
-import { TextInput as PaperTextInput } from 'react-native-paper';
+import { Container } from './styles';
 import useTextInput from './useTextInput';
+
 export interface Props extends TextInputProps {
   label: string;
   error?: boolean;

--- a/src/components/text-input/useTextInput.ts
+++ b/src/components/text-input/useTextInput.ts
@@ -1,5 +1,6 @@
-import { Props } from '.';
 import { useState, useCallback } from 'react';
+
+import { Props } from './';
 
 const useTextInput = (props: Props) => {
   const [value, setValue] = useState(props.value || '');

--- a/src/components/touchable-ripple/index.tsx
+++ b/src/components/touchable-ripple/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TouchableRipple as PaperTouchableRipple } from 'react-native-paper';
+
 import { Container } from './styles';
 
 interface Props {

--- a/src/errors/__tests__/useFirebaseErrors.test.ts
+++ b/src/errors/__tests__/useFirebaseErrors.test.ts
@@ -1,5 +1,6 @@
 import useFirebaseError from '@errors/useFirebaseError';
 import appLocale from '@locales';
+
 import * as auth from '../firebase/auth';
 
 const strings = appLocale();

--- a/src/errors/__tests__/useFormError.test.ts
+++ b/src/errors/__tests__/useFormError.test.ts
@@ -1,6 +1,8 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+
 import useFormError from '@errors/useFormError';
 import { ProductListForm } from '@store/product-list/types';
-import { act, renderHook } from '@testing-library/react-hooks';
+
 import * as forms from '../forms';
 
 describe('useFormError', () => {

--- a/src/errors/forms/__tests__/index.test.ts
+++ b/src/errors/forms/__tests__/index.test.ts
@@ -1,6 +1,7 @@
-import validateForm from '..';
-import { productListErrors } from '../schemas/__mocks__/product-items.mock';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+
+import validateForm from '../';
+import { productListErrors } from '../schemas/__mocks__/product-items.mock';
 
 describe('Testando todo o fluxo de erros de formulários', () => {
   test('deve retornar o objeto de erro formatado para o productItem se os valores forem vazios', async () => {

--- a/src/errors/forms/index.ts
+++ b/src/errors/forms/index.ts
@@ -1,6 +1,8 @@
-import { ProductItemForm, ProductListForm } from '@store/product-list/types';
 import { ValidationError } from 'yup';
+
 import { AuthLoginForm, AuthRegisterForm } from '@store/auth/types';
+import { ProductItemForm, ProductListForm } from '@store/product-list/types';
+
 import testSchema from './testSchema';
 
 export type FormName = 'productItem' | 'login' | 'register' | 'productList';

--- a/src/errors/forms/schemas/__mocks__/login.mock.ts
+++ b/src/errors/forms/schemas/__mocks__/login.mock.ts
@@ -1,4 +1,5 @@
 import appLocale from '@locales';
+
 import { generateError } from './product-items.mock';
 
 const strings = appLocale();

--- a/src/errors/forms/schemas/__mocks__/product-items.mock.ts
+++ b/src/errors/forms/schemas/__mocks__/product-items.mock.ts
@@ -1,6 +1,8 @@
-import appLocale from '@locales';
 import { ValidationError } from 'yup';
-import { ErrorInterface } from '../..';
+
+import appLocale from '@locales';
+
+import { ErrorInterface } from '../../';
 
 const strings = appLocale();
 

--- a/src/errors/forms/schemas/__mocks__/product-list.mock.ts
+++ b/src/errors/forms/schemas/__mocks__/product-list.mock.ts
@@ -1,4 +1,5 @@
 import appLocale from '@locales';
+
 import { generateError } from './product-items.mock';
 
 const strings = appLocale();

--- a/src/errors/forms/schemas/__mocks__/register.mock.ts
+++ b/src/errors/forms/schemas/__mocks__/register.mock.ts
@@ -1,4 +1,5 @@
 import appLocale from '@locales';
+
 import { generateError } from './product-items.mock';
 
 const strings = appLocale();

--- a/src/errors/forms/schemas/__tests__/login.test.ts
+++ b/src/errors/forms/schemas/__tests__/login.test.ts
@@ -1,6 +1,5 @@
-import testSchema from '../../testSchema';
-
 import * as loginErrors from '../__mocks__/login.mock';
+import testSchema from '../../testSchema';
 
 describe('Testando a validação do ProductList', () => {
   test('deve retornar true se todos os valores forem válidos', async () => {

--- a/src/errors/forms/schemas/__tests__/product-item.test.ts
+++ b/src/errors/forms/schemas/__tests__/product-item.test.ts
@@ -1,6 +1,5 @@
-import testSchema from '../../testSchema';
-
 import { productListErrors } from '../__mocks__/product-items.mock';
+import testSchema from '../../testSchema';
 
 describe('Testando a validação do ProductList', () => {
   test('deve retornar true se todos os valores forem válidos', async () => {

--- a/src/errors/forms/schemas/__tests__/product-list.test.ts
+++ b/src/errors/forms/schemas/__tests__/product-list.test.ts
@@ -1,6 +1,5 @@
-import testSchema from '../../testSchema';
-
 import * as productListErrors from '../__mocks__/product-list.mock';
+import testSchema from '../../testSchema';
 
 describe('Testando a validação do ProductList', () => {
   test('deve retornar true se todos os valores forem válidos', async () => {

--- a/src/errors/forms/schemas/__tests__/register.test.ts
+++ b/src/errors/forms/schemas/__tests__/register.test.ts
@@ -1,6 +1,5 @@
-import testSchema from '../../testSchema';
-
 import * as loginErrors from '../__mocks__/register.mock';
+import testSchema from '../../testSchema';
 
 describe('Testando a validação do ProductList', () => {
   test('deve retornar true se todos os valores forem válidos', async () => {

--- a/src/errors/forms/schemas/product-item.ts
+++ b/src/errors/forms/schemas/product-item.ts
@@ -1,4 +1,5 @@
 import * as Yup from 'yup';
+
 import appLocale from '@locales';
 
 const strings = appLocale();

--- a/src/errors/forms/schemas/product-list.ts
+++ b/src/errors/forms/schemas/product-list.ts
@@ -1,4 +1,5 @@
 import * as Yup from 'yup';
+
 import appLocale from '@locales';
 
 const strings = appLocale();

--- a/src/errors/forms/schemas/register.ts
+++ b/src/errors/forms/schemas/register.ts
@@ -1,4 +1,5 @@
 import * as Yup from 'yup';
+
 import appLocale from '@locales';
 
 const strings = appLocale();

--- a/src/errors/forms/testSchema.ts
+++ b/src/errors/forms/testSchema.ts
@@ -1,9 +1,10 @@
 import * as Yup from 'yup';
-import { FormName, FormValues } from '.';
+
+import { FormName, FormValues } from './';
+import login from './schemas/login';
 import productItem from './schemas/product-item';
 import productList from './schemas/product-list';
 import register from './schemas/register';
-import login from './schemas/login';
 
 const validationSchemas = {
   productItem,

--- a/src/errors/useFirebaseError.ts
+++ b/src/errors/useFirebaseError.ts
@@ -1,7 +1,8 @@
-import * as auth from './firebase/auth';
-import * as productLists from './firebase/productLists';
-import { RegexValues } from './firebase/auth';
 import appLocale from '@locales';
+
+import * as auth from './firebase/auth';
+import { RegexValues } from './firebase/auth';
+import * as productLists from './firebase/productLists';
 
 const strings = appLocale();
 

--- a/src/errors/useFormError.ts
+++ b/src/errors/useFormError.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+
 import validateForm, { ErrorInterface, FormName, FormValues } from './forms';
 
 const useFormError = (props: {

--- a/src/firebase/__tests__/index.test.ts
+++ b/src/firebase/__tests__/index.test.ts
@@ -1,4 +1,4 @@
-import firebaseInit from '..';
+import firebaseInit from '../';
 import * as admob from '../admob';
 
 jest.mock('../admob', () => jest.fn());

--- a/src/firebase/admob.ts
+++ b/src/firebase/admob.ts
@@ -1,10 +1,10 @@
-import { useCallback, useEffect } from 'react';
 import admob, {
   MaxAdContentRating,
   InterstitialAd,
   AdEventType,
   TestIds,
 } from '@react-native-firebase/admob';
+import { useCallback, useEffect } from 'react';
 import Config from 'react-native-config';
 
 const admobInit = () => {

--- a/src/lib/__tests__/push-notification.test.ts
+++ b/src/lib/__tests__/push-notification.test.ts
@@ -1,5 +1,6 @@
-import { ChannelID, pushNotification } from '@lib/push-notification';
 import PushNotification from 'react-native-push-notification';
+
+import { ChannelID, pushNotification } from '@lib/push-notification';
 
 describe('Testes da lib PushNotification', () => {
   const localNotificationScheduleSpy = jest.spyOn(

--- a/src/locales/__tests__/index.test.ts
+++ b/src/locales/__tests__/index.test.ts
@@ -1,4 +1,5 @@
 import appLocale, { appCurrency } from '@locales';
+
 import stringsPTBR from '../ptBR';
 
 describe('Locale - useLocale', () => {

--- a/src/locales/ptBR/index.ts
+++ b/src/locales/ptBR/index.ts
@@ -1,10 +1,10 @@
 import auth from './auth';
 import errors from './errors';
 import general from './general';
-import unit from './unit';
-import stock from './stock';
 import productItems from './product-items';
 import productLists from './product-lists';
+import stock from './stock';
+import unit from './unit';
 
 export default {
   auth,

--- a/src/navigator/__tests__/useNavigator.test.ts
+++ b/src/navigator/__tests__/useNavigator.test.ts
@@ -1,9 +1,10 @@
-import * as reactRedux from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
+import * as reactRedux from 'react-redux';
+
+import { pushNotification } from '@lib/push-notification';
 import useNavigator from '@navigator/useNavigator';
 import { authSelectors } from '@store/auth';
 import { generalSelector } from '@store/general';
-import { pushNotification } from '@lib/push-notification';
 
 describe('Testando o Rehydrate', () => {
   const dispatch = jest.fn();

--- a/src/navigator/authenticated.tsx
+++ b/src/navigator/authenticated.tsx
@@ -1,13 +1,12 @@
-import React from 'react';
 import { createDrawerNavigator } from '@react-navigation/drawer';
+import React from 'react';
 
-import ProductNavigator from './product-navigator';
+import { Routes } from '@routes';
 
 import Drawer from './components/drawer';
-
-import UnauthenticatedNavigator from './unauthenticated';
-import { Routes } from '@routes';
+import ProductNavigator from './product-navigator';
 import StockNavigator from './stock-navigator';
+import UnauthenticatedNavigator from './unauthenticated';
 
 export type AuthenticatedParamsList = {
   [Routes.ProductNavigator]: undefined;

--- a/src/navigator/components/drawer-bottom/__tests__/useDrawerBottom.test.ts
+++ b/src/navigator/components/drawer-bottom/__tests__/useDrawerBottom.test.ts
@@ -1,6 +1,8 @@
-import { authActions } from '@store/auth';
 import { act, renderHook } from '@testing-library/react-hooks';
 import * as reactRedux from 'react-redux';
+
+import { authActions } from '@store/auth';
+
 import useDrawerBottom from '../useDrawerBottom';
 
 describe('Drawer Bottom - useDrawerBottom', () => {

--- a/src/navigator/components/drawer-bottom/index.tsx
+++ b/src/navigator/components/drawer-bottom/index.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-
 import { View } from 'react-native';
+
 import Button from '@components/button';
+
 import useDrawerBottom from './useDrawerBottom';
 
 const DrawerBottom = () => {

--- a/src/navigator/components/drawer-bottom/useDrawerBottom.ts
+++ b/src/navigator/components/drawer-bottom/useDrawerBottom.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+
 import { authActions } from '@store/auth';
 
 const useDrawerBottom = () => {

--- a/src/navigator/components/drawer/index.tsx
+++ b/src/navigator/components/drawer/index.tsx
@@ -1,13 +1,15 @@
-import * as React from 'react';
 import {
   DrawerContentScrollView,
   DrawerItemList,
   DrawerContentComponentProps,
   DrawerContentOptions,
 } from '@react-navigation/drawer';
+import * as React from 'react';
+
+import { Routes } from '@routes';
+
 import DrawerBottom from '../drawer-bottom';
 import UserCard from '../user-card';
-import { Routes } from '@routes';
 
 const Drawer = (props: DrawerContentComponentProps<DrawerContentOptions>) => {
   const { state, ...rest } = props;

--- a/src/navigator/components/user-card/__tests__/useUserCard.test.ts
+++ b/src/navigator/components/user-card/__tests__/useUserCard.test.ts
@@ -1,8 +1,10 @@
 import { act, renderHook } from '@testing-library/react-hooks';
 import * as reactRedux from 'react-redux';
-import useUserCard from '../useUserCard';
-import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
 import { Routes } from '@routes';
+import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
+import useUserCard from '../useUserCard';
 
 describe('User Card - useUserCard', () => {
   jest.spyOn(reactRedux, 'useSelector').mockReturnValue({

--- a/src/navigator/components/user-card/index.tsx
+++ b/src/navigator/components/user-card/index.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
 
+import appLocale from '@locales';
+import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types';
+
 import {
   Container,
   UnauthorizedText,
@@ -8,8 +11,6 @@ import {
   UnauthorizedButton,
 } from './styles';
 import useUserCard from './useUserCard';
-import appLocale from '@locales';
-import { DrawerNavigationHelpers } from '@react-navigation/drawer/lib/typescript/src/types';
 
 const strings = appLocale();
 export interface Props {

--- a/src/navigator/components/user-card/styles.ts
+++ b/src/navigator/components/user-card/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 
 export const Container = styled.View`

--- a/src/navigator/components/user-card/useUserCard.ts
+++ b/src/navigator/components/user-card/useUserCard.ts
@@ -1,8 +1,10 @@
-import { useSelector } from 'react-redux';
-import { authSelectors } from '@store/auth';
 import { useCallback } from 'react';
-import { Props } from '.';
+import { useSelector } from 'react-redux';
+
 import { Routes } from '@routes';
+import { authSelectors } from '@store/auth';
+
+import { Props } from './';
 
 const useUserCard = (props: Props) => {
   const authReducer = useSelector(authSelectors.getState);

--- a/src/navigator/index.tsx
+++ b/src/navigator/index.tsx
@@ -1,13 +1,13 @@
-import React from 'react';
 import { NavigationContainer } from '@react-navigation/native';
+import React from 'react';
+
+import AdmobBanner from '@components/admob-banner';
+import FullscreenLoader from '@components/fullscreen-loader';
 
 import AuthenticatedNavigator from './authenticated';
-import UnauthenticatedNavigator from './unauthenticated';
-
-import useNavigator from './useNavigator';
-import FullscreenLoader from '@components/fullscreen-loader';
 import { setNavigator } from './services/navigationService';
-import AdmobBanner from '@components/admob-banner';
+import UnauthenticatedNavigator from './unauthenticated';
+import useNavigator from './useNavigator';
 
 const AppNavigator = () => {
   const { isAuthenticated, isRehydrated } = useNavigator();

--- a/src/navigator/product-navigator.tsx
+++ b/src/navigator/product-navigator.tsx
@@ -1,16 +1,16 @@
-import React from 'react';
 import {
   createStackNavigator,
   TransitionPresets,
 } from '@react-navigation/stack';
-import ProductItems from '@routes/product-list/product-items';
-import NewListItem from '@routes/new-item';
+import React from 'react';
 
 import { Routes } from '@routes';
-import { ProductItem, ProductList } from '@store/product-list/types';
-import ProductLists from '@routes/product-list/product-lists';
+import NewListItem from '@routes/new-item';
 import NewList from '@routes/product-list/new-list';
+import ProductItems from '@routes/product-list/product-items';
+import ProductLists from '@routes/product-list/product-lists';
 import { productListActions } from '@store/product-list';
+import { ProductItem, ProductList } from '@store/product-list/types';
 import { stockActions } from '@store/stock';
 
 export type ProductNavigatorParamsList = {

--- a/src/navigator/services/__tests__/navigationService.test.ts
+++ b/src/navigator/services/__tests__/navigationService.test.ts
@@ -2,7 +2,9 @@ import {
   CommonActions,
   NavigationContainerRef,
 } from '@react-navigation/native';
+
 import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
 import navigationService, { setNavigator } from '../navigationService';
 
 jest.mock('@react-navigation/native');

--- a/src/navigator/stock-navigator.tsx
+++ b/src/navigator/stock-navigator.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
 import {
   createStackNavigator,
   TransitionPresets,
 } from '@react-navigation/stack';
-import NewListItem from '@routes/new-item';
+import React from 'react';
 
 import { Routes } from '@routes';
-import { ProductItem } from '@store/product-list/types';
-import { productListActions } from '@store/product-list';
-import { stockActions } from '@store/stock';
+import NewListItem from '@routes/new-item';
 import Stock from '@routes/stock';
+import { productListActions } from '@store/product-list';
+import { ProductItem } from '@store/product-list/types';
+import { stockActions } from '@store/stock';
 
 export type StockNavigatorParamsList = {
   [Routes.Stock]: undefined;

--- a/src/navigator/unauthenticated.tsx
+++ b/src/navigator/unauthenticated.tsx
@@ -1,8 +1,7 @@
+import { createStackNavigator } from '@react-navigation/stack';
 import React from 'react';
 
-import { createStackNavigator } from '@react-navigation/stack';
 import { Routes } from '@routes';
-
 import Login from '@routes/auth/login';
 import RegisterUser from '@routes/auth/register';
 

--- a/src/navigator/useNavigator.ts
+++ b/src/navigator/useNavigator.ts
@@ -1,8 +1,9 @@
 import { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+import { pushNotification } from '@lib/push-notification';
 import { authSelectors } from '@store/auth';
 import { generalSelector } from '@store/general';
-import { pushNotification } from '@lib/push-notification';
 import { notificationActions } from '@store/notification';
 
 const useNavigator = () => {

--- a/src/routes/auth/login/__tests__/useForm.test.ts
+++ b/src/routes/auth/login/__tests__/useForm.test.ts
@@ -1,6 +1,8 @@
 import { renderHook, act } from '@testing-library/react-hooks';
-import useForm from '../useForm';
+
 import * as useErrorForm from '@errors/useFormError';
+
+import useForm from '../useForm';
 
 const validateError = jest.fn().mockResolvedValue(true);
 const handleErrorMessage = jest.fn();

--- a/src/routes/auth/login/__tests__/useLogin.test.ts
+++ b/src/routes/auth/login/__tests__/useLogin.test.ts
@@ -1,9 +1,11 @@
 import * as navigation from '@react-navigation/native';
-import { Routes } from '@routes';
-import { authActions } from '@store/auth';
 import { act, renderHook } from '@testing-library/react-hooks';
 import * as reactRedux from 'react-redux';
+
+import { Routes } from '@routes';
+import { authActions } from '@store/auth';
 import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
 import useLogin from '../useLogin';
 
 jest.mock('@react-navigation/native');

--- a/src/routes/auth/login/index.tsx
+++ b/src/routes/auth/login/index.tsx
@@ -1,6 +1,16 @@
+import { StackScreenProps } from '@react-navigation/stack';
 import * as React from 'react';
 
-import useLogin from './useLogin';
+import Logo from '@assets/images/logo.svg';
+import Button from '@components/button';
+import Divider from '@components/divider';
+import FullscreenLoader from '@components/fullscreen-loader';
+import Header from '@components/header';
+import TextInput from '@components/text-input';
+import appLocale from '@locales';
+import { UnauthenticatedParamsList } from '@navigator/unauthenticated';
+import { dimensions } from '@styles';
+
 import {
   Container,
   LogoContainer,
@@ -8,17 +18,8 @@ import {
   LoginContainer,
   SocialContainer,
 } from './styles';
-import Logo from '@assets/images/logo.svg';
-import { dimensions } from '@styles';
-import TextInput from '@components/text-input';
-import Button from '@components/button';
-import { StackScreenProps } from '@react-navigation/stack';
-import { UnauthenticatedParamsList } from '@navigator/unauthenticated';
-import FullscreenLoader from '@components/fullscreen-loader';
 import useForm from './useForm';
-import appLocale from '@locales';
-import Divider from '@components/divider';
-import Header from '@components/header';
+import useLogin from './useLogin';
 
 const strings = appLocale();
 

--- a/src/routes/auth/login/styles.ts
+++ b/src/routes/auth/login/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 
 const Container = styled.ScrollView`

--- a/src/routes/auth/login/useForm.ts
+++ b/src/routes/auth/login/useForm.ts
@@ -1,5 +1,6 @@
-import useFormError from '@errors/useFormError';
 import { useCallback, useState } from 'react';
+
+import useFormError from '@errors/useFormError';
 
 const useForm = () => {
   const [email, setEmail] = useState('');

--- a/src/routes/auth/login/useLogin.ts
+++ b/src/routes/auth/login/useLogin.ts
@@ -1,10 +1,10 @@
+import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { useCallback } from 'react';
-import { authActions, authSelectors } from '@store/auth';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { Routes } from '@routes';
-import { NavigationProp, useNavigation } from '@react-navigation/native';
 import { UnauthenticatedParamsList } from '@navigator/unauthenticated';
+import { Routes } from '@routes';
+import { authActions, authSelectors } from '@store/auth';
 import { AuthLoginForm } from '@store/auth/types';
 
 type NavProps = NavigationProp<UnauthenticatedParamsList, 'Login'>;

--- a/src/routes/auth/register/__tests__/useForm.test.ts
+++ b/src/routes/auth/register/__tests__/useForm.test.ts
@@ -1,8 +1,10 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import useForm from '../useForm';
-import * as useErrorForm from '@errors/useFormError';
 import * as navigation from '@react-navigation/native';
+import { renderHook, act } from '@testing-library/react-hooks';
+
+import * as useErrorForm from '@errors/useFormError';
 import { Routes } from '@routes';
+
+import useForm from '../useForm';
 
 const validateError = jest.fn().mockResolvedValue(true);
 const handleErrorMessage = jest.fn();

--- a/src/routes/auth/register/__tests__/useRegister.test.ts
+++ b/src/routes/auth/register/__tests__/useRegister.test.ts
@@ -1,7 +1,9 @@
 import { act, renderHook } from '@testing-library/react-hooks';
-import useRegister from '../useRegister';
 import * as reactRedux from 'react-redux';
+
 import { authActions } from '@store/auth';
+
+import useRegister from '../useRegister';
 
 describe('Register - useRegister', () => {
   const dispatch = jest.fn();

--- a/src/routes/auth/register/index.tsx
+++ b/src/routes/auth/register/index.tsx
@@ -1,14 +1,15 @@
 import * as React from 'react';
 
-import TextInput from '@components/text-input';
-import { Container } from './styles';
-import useRegister from './useRegister';
 import Button from '@components/button';
-import FullscreenLoader from '@components/fullscreen-loader';
-import useForm from './useForm';
-import appLocale from '@locales';
-import Header from '@components/header';
 import Divider from '@components/divider';
+import FullscreenLoader from '@components/fullscreen-loader';
+import Header from '@components/header';
+import TextInput from '@components/text-input';
+import appLocale from '@locales';
+
+import { Container } from './styles';
+import useForm from './useForm';
+import useRegister from './useRegister';
 
 const strings = appLocale();
 

--- a/src/routes/auth/register/styles.ts
+++ b/src/routes/auth/register/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 
 const Container = styled.ScrollView`

--- a/src/routes/auth/register/useForm.ts
+++ b/src/routes/auth/register/useForm.ts
@@ -1,7 +1,8 @@
-import useFormError from '@errors/useFormError';
-import { UnauthenticatedParamsList } from '@navigator/unauthenticated';
 import { RouteProp, useRoute } from '@react-navigation/native';
 import { useCallback, useState } from 'react';
+
+import useFormError from '@errors/useFormError';
+import { UnauthenticatedParamsList } from '@navigator/unauthenticated';
 
 type RouteProps = RouteProp<UnauthenticatedParamsList, 'RegisterUser'>;
 

--- a/src/routes/auth/register/useRegister.ts
+++ b/src/routes/auth/register/useRegister.ts
@@ -1,8 +1,8 @@
 import { useCallback } from 'react';
-
 import { useDispatch, useSelector } from 'react-redux';
-import actions from '@store/auth/actions';
+
 import { authSelectors } from '@store/auth';
+import actions from '@store/auth/actions';
 import { AuthRegisterForm } from '@store/auth/types';
 
 interface Props {

--- a/src/routes/new-item/__tests__/constants.test.ts
+++ b/src/routes/new-item/__tests__/constants.test.ts
@@ -1,5 +1,6 @@
-import { unitList } from '../constants';
 import appLocale from '@locales';
+
+import { unitList } from '../constants';
 
 const strings = appLocale();
 

--- a/src/routes/new-item/__tests__/useForm.test.ts
+++ b/src/routes/new-item/__tests__/useForm.test.ts
@@ -1,7 +1,9 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import useForm from '../useForm';
 import * as navigation from '@react-navigation/native';
+import { renderHook, act } from '@testing-library/react-hooks';
+
 import * as useErrorForm from '@errors/useFormError';
+
+import useForm from '../useForm';
 
 const validateError = jest.fn().mockResolvedValue(true);
 const handleErrorMessage = jest.fn();

--- a/src/routes/new-item/__tests__/useNewItem.test.ts
+++ b/src/routes/new-item/__tests__/useNewItem.test.ts
@@ -1,8 +1,10 @@
-import * as reactRedux from 'react-redux';
-import { renderHook, act } from '@testing-library/react-hooks';
-import useNewItem from '../useNewItem';
-import { productListActions } from '@store/product-list';
 import * as navigation from '@react-navigation/native';
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as reactRedux from 'react-redux';
+
+import { productListActions } from '@store/product-list';
+
+import useNewItem from '../useNewItem';
 
 jest.mock('@react-navigation/native');
 

--- a/src/routes/new-item/containers/duedate-modal/index.tsx
+++ b/src/routes/new-item/containers/duedate-modal/index.tsx
@@ -1,5 +1,6 @@
-import DateTimePicker from '@components/datetimepicker';
 import React from 'react';
+
+import DateTimePicker from '@components/datetimepicker';
 
 export interface Props {
   setDueDate: (date: Date) => void;

--- a/src/routes/new-item/containers/unit-modal/__tests__/useUnitModal.test.ts
+++ b/src/routes/new-item/containers/unit-modal/__tests__/useUnitModal.test.ts
@@ -1,4 +1,5 @@
 import { act, renderHook } from '@testing-library/react-hooks';
+
 import useUnitModal from '../useUnitModal';
 
 describe('testando useUnitModal', () => {

--- a/src/routes/new-item/containers/unit-modal/index.tsx
+++ b/src/routes/new-item/containers/unit-modal/index.tsx
@@ -1,5 +1,7 @@
-import List, { PaperListData } from '@components/list';
 import React from 'react';
+
+import List, { PaperListData } from '@components/list';
+
 import { unitList } from '../../constants';
 import useUnitModal from './useUnitModal';
 

--- a/src/routes/new-item/containers/unit-modal/useUnitModal.ts
+++ b/src/routes/new-item/containers/unit-modal/useUnitModal.ts
@@ -1,6 +1,8 @@
-import { PaperListData } from '@components/list';
 import { useCallback, useState } from 'react';
-import { Props } from '.';
+
+import { PaperListData } from '@components/list';
+
+import { Props } from './';
 
 const useUnitModal = (props: Props) => {
   const [units] = useState(props.unit ? [props.unit] : []);

--- a/src/routes/new-item/index.tsx
+++ b/src/routes/new-item/index.tsx
@@ -1,23 +1,25 @@
 import * as React from 'react';
-import useNewItem from './useNewItem';
+import { Portal } from 'react-native-paper';
+
+import Dialog from '@components/dialog';
+import Divider from '@components/divider';
+import CircleButton from '@components/FAB';
+import Header from '@components/header';
+import TextInput from '@components/text-input';
+import TouchableRipple from '@components/touchable-ripple';
+import appLocale, { appCurrency } from '@locales';
+import { formatDate } from '@utils/date';
+
+import DueDateModal from './containers/duedate-modal';
+import UnitModal from './containers/unit-modal';
 import {
   Container,
   SubContainer,
   ButtonContainer,
   TwoColumnsContainer,
 } from './styles';
-import TextInput from '@components/text-input';
 import useForm from './useForm';
-import CircleButton from '@components/FAB';
-import appLocale, { appCurrency } from '@locales';
-import Header from '@components/header';
-import TouchableRipple from '@components/touchable-ripple';
-import Divider from '@components/divider';
-import UnitModal from './containers/unit-modal';
-import Dialog from '@components/dialog';
-import { Portal } from 'react-native-paper';
-import DueDateModal from './containers/duedate-modal';
-import { formatDate } from '@utils/date';
+import useNewItem from './useNewItem';
 
 const strings = appLocale();
 const currency = appCurrency();

--- a/src/routes/new-item/useForm.ts
+++ b/src/routes/new-item/useForm.ts
@@ -1,8 +1,9 @@
-import { useState, useCallback } from 'react';
-import useFormError from '@errors/useFormError';
 import { useRoute, RouteProp } from '@react-navigation/native';
-import { ProductNavigatorParamsList } from '@navigator/product-navigator';
+import { useState, useCallback } from 'react';
+
 import { PaperListData } from '@components/list';
+import useFormError from '@errors/useFormError';
+import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 
 type RouteProps = RouteProp<ProductNavigatorParamsList, 'NewListItem'>;
 

--- a/src/routes/new-item/useNewItem.ts
+++ b/src/routes/new-item/useNewItem.ts
@@ -1,10 +1,10 @@
-import { useDispatch, useSelector } from 'react-redux';
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { useCallback, useState } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 
+import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 import productListSelectors from '@store/product-list/selectors';
 import { ProductItem } from '@store/product-list/types';
-import { RouteProp, useRoute } from '@react-navigation/native';
-import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 
 interface Props {
   formParams: Partial<ProductItem>;

--- a/src/routes/product-list/new-list/__tests__/useForm.test.ts
+++ b/src/routes/product-list/new-list/__tests__/useForm.test.ts
@@ -1,7 +1,9 @@
-import { renderHook, act } from '@testing-library/react-hooks';
-import useForm from '../useForm';
 import * as navigation from '@react-navigation/native';
+import { renderHook, act } from '@testing-library/react-hooks';
+
 import * as useErrorForm from '@errors/useFormError';
+
+import useForm from '../useForm';
 
 const validateError = jest.fn().mockResolvedValue(true);
 const handleErrorMessage = jest.fn();

--- a/src/routes/product-list/new-list/__tests__/useNewList.test.ts
+++ b/src/routes/product-list/new-list/__tests__/useNewList.test.ts
@@ -1,8 +1,10 @@
-import * as reactRedux from 'react-redux';
 import { renderHook, act } from '@testing-library/react-hooks';
-import useNewList from '../useNewList';
+import * as reactRedux from 'react-redux';
+
 import { productListActions } from '@store/product-list';
 import * as admob from 'src/firebase/admob';
+
+import useNewList from '../useNewList';
 
 const dispatch = jest.fn();
 const showAd = jest.fn();

--- a/src/routes/product-list/new-list/index.tsx
+++ b/src/routes/product-list/new-list/index.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
-import { Container, SubContainer, ButtonContainer } from './styles';
-import TextInput from '@components/text-input';
-import useNewList from './useNewList';
-import useForm from './useForm';
 import CircleButton from '@components/FAB';
-import appLocale from '@locales';
 import Header from '@components/header';
+import TextInput from '@components/text-input';
+import appLocale from '@locales';
+
+import { Container, SubContainer, ButtonContainer } from './styles';
+import useForm from './useForm';
+import useNewList from './useNewList';
 
 const strings = appLocale();
 

--- a/src/routes/product-list/new-list/useForm.ts
+++ b/src/routes/product-list/new-list/useForm.ts
@@ -1,6 +1,7 @@
-import { useState, useCallback } from 'react';
-import useFormError from '@errors/useFormError';
 import { RouteProp, useRoute } from '@react-navigation/native';
+import { useState, useCallback } from 'react';
+
+import useFormError from '@errors/useFormError';
 import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 
 type RouteProps = RouteProp<ProductNavigatorParamsList, 'NewList'>;

--- a/src/routes/product-list/new-list/useNewList.ts
+++ b/src/routes/product-list/new-list/useNewList.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+
 import { productListActions } from '@store/product-list';
 import { ProductList } from '@store/product-list/types';
 import { useInterstitialAd } from 'src/firebase/admob';

--- a/src/routes/product-list/product-items/__tests__/useProductItems.test.ts
+++ b/src/routes/product-list/product-items/__tests__/useProductItems.test.ts
@@ -1,12 +1,12 @@
-import * as reactRedux from 'react-redux';
 import * as navigation from '@react-navigation/native';
-
-import { ProductListBuilderMock } from '@store/product-list/__mocks__/productListBuilder.mock';
-import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
 import { renderHook } from '@testing-library/react-hooks';
+import * as reactRedux from 'react-redux';
+
+import { productListActions } from '@store/product-list';
+import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '@store/product-list/__mocks__/productListBuilder.mock';
 
 import useProductItems from '../useProductItems';
-import { productListActions } from '@store/product-list';
 
 jest.mock('@react-navigation/native');
 

--- a/src/routes/product-list/product-items/components/item-card/__tests__/useItemCard.test.ts
+++ b/src/routes/product-list/product-items/components/item-card/__tests__/useItemCard.test.ts
@@ -1,11 +1,13 @@
-import * as reactRedux from 'react-redux';
 import * as navigation from '@react-navigation/native';
-import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
 import { renderHook, act } from '@testing-library/react-hooks';
-import useItemCard from '../useItemCard';
-import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import * as reactRedux from 'react-redux';
+
 import { Routes } from '@routes';
 import { productListActions } from '@store/product-list';
+import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
+import useItemCard from '../useItemCard';
 
 jest.mock('@react-navigation/native');
 

--- a/src/routes/product-list/product-items/components/item-card/index.tsx
+++ b/src/routes/product-list/product-items/components/item-card/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import { ProductItem } from '@store/product-list/types';
-import useItemCard from './useItemCard';
+
 import ProductItemComponent from '@components/product-item';
+import { ProductItem } from '@store/product-list/types';
+
+import useItemCard from './useItemCard';
 
 export interface Props {
   listId: string;

--- a/src/routes/product-list/product-items/components/item-card/useItemCard.ts
+++ b/src/routes/product-list/product-items/components/item-card/useItemCard.ts
@@ -1,10 +1,12 @@
-import { Props } from '.';
-import { useCallback } from 'react';
-import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
-import { Routes } from '@routes';
+import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
+
+import { ProductNavigatorParamsList } from '@navigator/product-navigator';
+import { Routes } from '@routes';
 import { productListActions } from '@store/product-list';
+
+import { Props } from './';
 
 type NavProps = NavigationProp<ProductNavigatorParamsList, 'ProductItems'>;
 

--- a/src/routes/product-list/product-items/containers/footer/__tests__/useFooter.test.ts
+++ b/src/routes/product-list/product-items/containers/footer/__tests__/useFooter.test.ts
@@ -1,10 +1,12 @@
 import * as navigation from '@react-navigation/native';
-import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
 import { renderHook, act } from '@testing-library/react-hooks';
-import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
-import useFooter from '../useFooter';
+
 import { Routes } from '@routes';
 import { productListActions } from '@store/product-list';
+import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
+import useFooter from '../useFooter';
 
 const mockProductItem = new ProductItemBuilderMock()
   .withName('Produto 1')

--- a/src/routes/product-list/product-items/containers/footer/index.tsx
+++ b/src/routes/product-list/product-items/containers/footer/index.tsx
@@ -1,4 +1,11 @@
 import React from 'react';
+
+import FAB from '@components/FAB';
+import Subheading from '@components/subheading';
+import Text from '@components/text';
+import appLocale, { appCurrency } from '@locales';
+import { ProductItems } from '@store/product-list/types';
+
 import {
   Container,
   ButtonContainer,
@@ -6,12 +13,7 @@ import {
   TextSubContainer,
   SubContainer,
 } from './styles';
-import FAB from '@components/FAB';
-import { ProductItems } from '@store/product-list/types';
 import useFooter from './useFooter';
-import Subheading from '@components/subheading';
-import appLocale, { appCurrency } from '@locales';
-import Text from '@components/text';
 
 export interface Props {
   productItems: ProductItems;

--- a/src/routes/product-list/product-items/containers/footer/styles.ts
+++ b/src/routes/product-list/product-items/containers/footer/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 import theme from 'src/styles/theme';
 

--- a/src/routes/product-list/product-items/containers/footer/useFooter.ts
+++ b/src/routes/product-list/product-items/containers/footer/useFooter.ts
@@ -1,9 +1,11 @@
-import { Props } from '.';
-import { useCallback, useState, useEffect } from 'react';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
+import { useCallback, useState, useEffect } from 'react';
+
 import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 import { Routes } from '@routes';
 import { productListActions } from '@store/product-list';
+
+import { Props } from './';
 
 type NavProps = NavigationProp<ProductNavigatorParamsList, 'ProductItems'>;
 

--- a/src/routes/product-list/product-items/index.tsx
+++ b/src/routes/product-list/product-items/index.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { Container } from './styles';
-import useProductItems from './useProductItems';
+import { FlatList } from 'react-native';
 
-import Footer from './containers/footer';
-import ItemCard from './components/item-card';
 import Header from '@components/header';
 import appLocale from '@locales';
 import { ProductItem } from '@store/product-list/types';
-import { FlatList } from 'react-native';
+
+import ItemCard from './components/item-card';
+import Footer from './containers/footer';
+import { Container } from './styles';
+import useProductItems from './useProductItems';
 
 const strings = appLocale();
 

--- a/src/routes/product-list/product-items/useProductItems.ts
+++ b/src/routes/product-list/product-items/useProductItems.ts
@@ -1,10 +1,10 @@
+import { RouteProp, useRoute } from '@react-navigation/native';
 import { useEffect, useCallback, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { RouteProp, useRoute } from '@react-navigation/native';
 
-import { filterByID } from '@utils/filters';
-import { productListSelectors, productListActions } from '@store/product-list';
 import { ProductNavigatorParamsList } from '@navigator/product-navigator';
+import { productListSelectors, productListActions } from '@store/product-list';
+import { filterByID } from '@utils/filters';
 import { sortByDate } from '@utils/sort';
 
 type RouteProps = RouteProp<ProductNavigatorParamsList, 'ProductItems'>;

--- a/src/routes/product-list/product-lists/__tests__/useProductLists.test.ts
+++ b/src/routes/product-list/product-lists/__tests__/useProductLists.test.ts
@@ -1,10 +1,12 @@
 import * as navigation from '@react-navigation/native';
+import { act, renderHook } from '@testing-library/react-hooks';
+import * as reactRedux from 'react-redux';
+
 import { Routes } from '@routes';
 import { productListActions } from '@store/product-list';
 import { ProductListBuilderMock } from '@store/product-list/__mocks__/productListBuilder.mock';
-import { act, renderHook } from '@testing-library/react-hooks';
-import * as reactRedux from 'react-redux';
 import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
 import useProductLists from '../useProductLists';
 
 jest.mock('@react-navigation/native');

--- a/src/routes/product-list/product-lists/components/list-card/__tests__/useListCard.test.ts
+++ b/src/routes/product-list/product-lists/components/list-card/__tests__/useListCard.test.ts
@@ -1,15 +1,17 @@
 import * as navigation from '@react-navigation/native';
-import { Routes } from '@routes';
-import { ProductListBuilderMock } from '@store/product-list/__mocks__/productListBuilder.mock';
 import { act, renderHook } from '@testing-library/react-hooks';
 import { Alert } from 'react-native';
 import * as reactRedux from 'react-redux';
-import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
-import useListCard from '../useListCard';
-import { productListActions } from '@store/product-list';
-import { ProductList } from '@store/product-list/types';
+
 import appLocale from '@locales';
+import { Routes } from '@routes';
+import { productListActions } from '@store/product-list';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '@store/product-list/__mocks__/productListBuilder.mock';
+import { ProductList } from '@store/product-list/types';
+import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
+import useListCard from '../useListCard';
 
 const strings = appLocale();
 

--- a/src/routes/product-list/product-lists/components/list-card/index.tsx
+++ b/src/routes/product-list/product-lists/components/list-card/index.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import { ProductList } from '@store/product-list/types';
+
 import { Container, ListTitle } from './styles';
 import useListCard from './useListCard';
 

--- a/src/routes/product-list/product-lists/components/list-card/styles.ts
+++ b/src/routes/product-list/product-lists/components/list-card/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 
 export const Container = styled.TouchableOpacity`

--- a/src/routes/product-list/product-lists/components/list-card/useListCard.ts
+++ b/src/routes/product-list/product-lists/components/list-card/useListCard.ts
@@ -1,12 +1,14 @@
-import { useCallback, useState, useEffect } from 'react';
-import { Props } from '.';
-import { Alert } from 'react-native';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
+import { useCallback, useState, useEffect } from 'react';
+import { Alert } from 'react-native';
+import { useDispatch } from 'react-redux';
+
+import appLocale from '@locales';
 import { ProductNavigatorParamsList } from '@navigator/product-navigator';
 import { Routes } from '@routes';
 import { productListActions } from '@store/product-list';
-import { useDispatch } from 'react-redux';
-import appLocale from '@locales';
+
+import { Props } from './';
 
 const strings = appLocale();
 type NavProps = NavigationProp<ProductNavigatorParamsList, 'ProductLists'>;

--- a/src/routes/product-list/product-lists/index.tsx
+++ b/src/routes/product-list/product-lists/index.tsx
@@ -1,14 +1,14 @@
 import React from 'react';
-
-import { Container, ButtonContainer } from './styles';
-import useProductLists from './useProductLists';
-import ListCard from './components/list-card';
-
 import { FlatList } from 'react-native';
-import { ProductList } from '@store/product-list/types';
+
 import CircleButton from '@components/FAB';
 import Header from '@components/header';
 import appLocale from '@locales';
+import { ProductList } from '@store/product-list/types';
+
+import ListCard from './components/list-card';
+import { Container, ButtonContainer } from './styles';
+import useProductLists from './useProductLists';
 
 const strings = appLocale();
 

--- a/src/routes/product-list/product-lists/styles.ts
+++ b/src/routes/product-list/product-lists/styles.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components/native';
+
 import { dimensions } from '@styles';
 
 export const Container = styled.View`

--- a/src/routes/product-list/product-lists/useProductLists.ts
+++ b/src/routes/product-list/product-lists/useProductLists.ts
@@ -1,9 +1,10 @@
-import { useSelector, useDispatch } from 'react-redux';
-import { productListSelectors, productListActions } from '@store/product-list';
-import { useCallback, useEffect, useState } from 'react';
-import { Routes } from '@routes';
 import { useNavigation, NavigationProp } from '@react-navigation/native';
+import { useCallback, useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+
 import { ProductNavigatorParamsList } from '@navigator/product-navigator';
+import { Routes } from '@routes';
+import { productListSelectors, productListActions } from '@store/product-list';
 import { sortByDate } from '@utils/sort';
 
 type NavProps = NavigationProp<ProductNavigatorParamsList, 'ProductLists'>;

--- a/src/routes/stock/__tests__/useStock.test.ts
+++ b/src/routes/stock/__tests__/useStock.test.ts
@@ -1,11 +1,13 @@
-import { stockActions, stockSelectors } from '@store/stock';
-import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
-import * as reactRedux from 'react-redux';
 import * as navigation from '@react-navigation/native';
-import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
 import { act, renderHook } from '@testing-library/react-hooks';
-import useStock from '../useStock';
+import * as reactRedux from 'react-redux';
+
 import { Routes } from '@routes';
+import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
+import { stockActions, stockSelectors } from '@store/stock';
+import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
+import useStock from '../useStock';
 
 jest.mock('@react-navigation/native');
 

--- a/src/routes/stock/components/item-card/__tests__/useItemCard.test.ts
+++ b/src/routes/stock/components/item-card/__tests__/useItemCard.test.ts
@@ -1,12 +1,14 @@
 import * as navigation from '@react-navigation/native';
-import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
-import useItemCard from '../useItemCard';
-import * as reactRedux from 'react-redux';
 import { act, renderHook } from '@testing-library/react-hooks';
-import { Routes } from '@routes';
-import { stockActions } from '@store/stock';
 import { Alert } from 'react-native';
+import * as reactRedux from 'react-redux';
+
+import { Routes } from '@routes';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { stockActions } from '@store/stock';
+import { useNavigationMocks } from 'src/__tests__/navigation-mocks';
+
+import useItemCard from '../useItemCard';
 
 const dispatch = jest.fn();
 

--- a/src/routes/stock/components/item-card/index.tsx
+++ b/src/routes/stock/components/item-card/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { ProductItem } from '@store/product-list/types';
 import ProductItemComponent from '@components/product-item';
+import { ProductItem } from '@store/product-list/types';
+
 import useItemCard from './useItemCard';
 
 export interface Props {

--- a/src/routes/stock/components/item-card/useItemCard.ts
+++ b/src/routes/stock/components/item-card/useItemCard.ts
@@ -1,10 +1,12 @@
-import { StockNavigatorParamsList } from '@navigator/stock-navigator';
 import { NavigationProp, useNavigation } from '@react-navigation/native';
-import { Routes } from '@routes';
-import { stockActions } from '@store/stock';
 import { useCallback } from 'react';
 import { useDispatch } from 'react-redux';
-import { Props } from '.';
+
+import { StockNavigatorParamsList } from '@navigator/stock-navigator';
+import { Routes } from '@routes';
+import { stockActions } from '@store/stock';
+
+import { Props } from './';
 
 type NavProps = NavigationProp<StockNavigatorParamsList, 'Stock'>;
 

--- a/src/routes/stock/index.tsx
+++ b/src/routes/stock/index.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 import { FlatList } from 'react-native';
+
+import FABButton from '@components/FAB';
 import Header from '@components/header';
 import appLocale from '@locales';
-import FABButton from '@components/FAB';
+
+import ItemCard from './components/item-card';
 import { ButtonContainer } from './styles';
 import useStock from './useStock';
-import ItemCard from './components/item-card';
 
 const strings = appLocale();
 const Stock = () => {

--- a/src/routes/stock/styles.ts
+++ b/src/routes/stock/styles.ts
@@ -1,5 +1,6 @@
-import { dimensions } from '@styles';
 import styled from 'styled-components/native';
+
+import { dimensions } from '@styles';
 
 export const Container = styled.ScrollView``;
 

--- a/src/routes/stock/useStock.ts
+++ b/src/routes/stock/useStock.ts
@@ -1,8 +1,9 @@
 import { useNavigation } from '@react-navigation/native';
-import { Routes } from '@routes';
-import { stockActions, stockSelectors } from '@store/stock';
 import { useCallback, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
+
+import { Routes } from '@routes';
+import { stockActions, stockSelectors } from '@store/stock';
 
 const useStock = () => {
   const isLoading = useSelector(stockSelectors.isLoading);

--- a/src/store/__mocks__/AppStateMockBuilder.mock.ts
+++ b/src/store/__mocks__/AppStateMockBuilder.mock.ts
@@ -1,10 +1,12 @@
-import { ProductListState } from '@store/product-list/types';
+import { PersistState } from 'redux-persist';
+
 import { AuthState } from '@store/auth/types';
 import { GeneralState } from '@store/general/types';
 import { NotificationState } from '@store/notification/types';
-import { initialAppState } from './initialAppState.mock';
-import { PersistState } from 'redux-persist';
+import { ProductListState } from '@store/product-list/types';
 import { StockState } from '@store/stock/types';
+
+import { initialAppState } from './initialAppState.mock';
 
 export class AppStateMockBuilder {
   _persist: PersistState = initialAppState._persist;

--- a/src/store/__tests__/index.test.ts
+++ b/src/store/__tests__/index.test.ts
@@ -1,8 +1,9 @@
 import AsyncStorage from '@react-native-community/async-storage';
-import configureStore from '@store';
+import * as redux from 'redux';
 import * as reduxPersist from 'redux-persist';
 import * as reduxSaga from 'redux-saga';
-import * as redux from 'redux';
+
+import configureStore from '@store';
 
 jest.mock('@react-native-community/async-storage', () => ({}));
 

--- a/src/store/auth/__tests__/actions.test.ts
+++ b/src/store/auth/__tests__/actions.test.ts
@@ -1,6 +1,8 @@
+import { mockCurrentUser } from 'src/__tests__/firebase-mocks';
+
 import { authActions } from '../';
 import { AuthTypes } from '../types';
-import { mockCurrentUser } from 'src/__tests__/firebase-mocks';
+
 describe('Auth Actions', () => {
   test.each([
     ['logout', authActions.logout(), { type: AuthTypes.LOGOUT }],

--- a/src/store/auth/__tests__/models.test.ts
+++ b/src/store/auth/__tests__/models.test.ts
@@ -1,6 +1,8 @@
-import * as models from '../models';
 import auth from '@react-native-firebase/auth';
+
 import { mockCurrentUser } from 'src/__tests__/firebase-mocks';
+
+import * as models from '../models';
 
 jest.mock('@react-native-firebase/auth', () =>
   jest.fn().mockReturnValue({

--- a/src/store/auth/__tests__/reducer.test.ts
+++ b/src/store/auth/__tests__/reducer.test.ts
@@ -1,6 +1,7 @@
-import authReducer from '../reducer';
-import { authActions } from '..';
 import { mockCurrentUser } from 'src/__tests__/firebase-mocks';
+
+import { authActions } from '../';
+import authReducer from '../reducer';
 import { AuthAction, AuthState, AuthTypes } from '../types';
 
 describe('Auth Reducer', () => {

--- a/src/store/auth/__tests__/sagas.test.ts
+++ b/src/store/auth/__tests__/sagas.test.ts
@@ -1,16 +1,18 @@
-import { authModels, authActions, authSelectors } from '../';
+import { put, call, select } from 'redux-saga/effects';
+
+import useFirebaseError from '@errors/useFirebaseError';
+import appLocale from '@locales';
+import navigationService from '@navigator/services/navigationService';
+import { notificationActions } from '@store/notification';
 import { mockCurrentUser } from 'src/__tests__/firebase-mocks';
+
+import { authModels, authActions, authSelectors } from '../';
 import {
   requestLoginEmailPassword,
   requestLogout,
   requestRegisterEmailPassword,
 } from '../sagas';
-import { put, call, select } from 'redux-saga/effects';
-import { notificationActions } from '@store/notification';
-import navigationService from '@navigator/services/navigationService';
 import { notificationMessages } from '../utils';
-import useFirebaseError from '@errors/useFirebaseError';
-import appLocale from '@locales';
 
 const strings = appLocale();
 

--- a/src/store/auth/__tests__/selectors.test.ts
+++ b/src/store/auth/__tests__/selectors.test.ts
@@ -1,6 +1,7 @@
-import { authSelectors } from '../';
 import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
 import { mockCurrentUser } from 'src/__tests__/firebase-mocks';
+
+import { authSelectors } from '../';
 
 describe('Testando AuthSelectors', () => {
   test('deve retornar o state correto', () => {

--- a/src/store/auth/actions.ts
+++ b/src/store/auth/actions.ts
@@ -1,5 +1,6 @@
-import { AuthTypes, AuthAction, AuthRegisterForm } from './types';
 import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+
+import { AuthTypes, AuthAction, AuthRegisterForm } from './types';
 
 const actions = {
   logout: () => ({ type: AuthTypes.LOGOUT }),

--- a/src/store/auth/index.ts
+++ b/src/store/auth/index.ts
@@ -1,6 +1,6 @@
 import actions from './actions';
-import * as selectors from './selectors';
 import * as models from './models';
+import * as selectors from './selectors';
 
 const authSelectors = { ...selectors };
 const authModels = { ...models };

--- a/src/store/auth/reducer.ts
+++ b/src/store/auth/reducer.ts
@@ -1,5 +1,5 @@
+import { authActions } from './';
 import { AuthAction, AuthState, AuthTypes, AuthReducer } from './types';
-import { authActions } from '.';
 
 const initialState: AuthState = {
   isLogged: false,

--- a/src/store/auth/sagas.ts
+++ b/src/store/auth/sagas.ts
@@ -1,10 +1,12 @@
-import { takeLatest, put, call, select } from 'redux-saga/effects';
-import { AuthTypes, AuthAction, AuthRegisterForm } from './types';
-import { authActions, authModels, authSelectors } from './';
 import { FirebaseAuthTypes } from '@react-native-firebase/auth';
+import { takeLatest, put, call, select } from 'redux-saga/effects';
+
 import useFirebaseError from '@errors/useFirebaseError';
-import { notificationActions } from '@store/notification';
 import navigationService from '@navigator/services/navigationService';
+import { notificationActions } from '@store/notification';
+
+import { authActions, authModels, authSelectors } from './';
+import { AuthTypes, AuthAction, AuthRegisterForm } from './types';
 import { notificationMessages } from './utils';
 
 const { getErrorMessage } = useFirebaseError('auth');

--- a/src/store/auth/selectors.ts
+++ b/src/store/auth/selectors.ts
@@ -1,4 +1,5 @@
 import { RootState } from '@store/reducers';
+
 import { AuthState } from './types';
 
 const getState = (state: RootState): AuthState => state.authReducer;

--- a/src/store/general/__tests__/reducer.test.ts
+++ b/src/store/general/__tests__/reducer.test.ts
@@ -1,6 +1,6 @@
+import generalActions from '../actions';
 import generalReducers from '../reducer';
 import { initialState } from '../reducer';
-import generalActions from '../actions';
 
 describe('General Reducers', () => {
   test('deve retornar o valor correto para o setLoading', () => {

--- a/src/store/general/__tests__/selectors.test.ts
+++ b/src/store/general/__tests__/selectors.test.ts
@@ -1,6 +1,6 @@
 import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
 
-import { generalSelector } from '..';
+import { generalSelector } from '../';
 
 describe('General Selectors', () => {
   it('deve retornar o general state corretamente', () => {

--- a/src/store/general/index.ts
+++ b/src/store/general/index.ts
@@ -1,5 +1,5 @@
-import { getGeneralState, getPersistState } from './selectors';
 import generalActions from './actions';
+import { getGeneralState, getPersistState } from './selectors';
 
 const generalSelector = { getGeneralState, getPersistState };
 

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,7 +1,7 @@
-import { createStore, Store, applyMiddleware } from 'redux';
 import AsyncStorage from '@react-native-community/async-storage';
-import { persistReducer, persistStore, Persistor } from 'redux-persist';
+import { createStore, Store, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';
+import { persistReducer, persistStore, Persistor } from 'redux-persist';
 import createSagaMiddleware from 'redux-saga';
 
 import rootReducer, { RootState } from './reducers';

--- a/src/store/notification/__tests__/actions.test.ts
+++ b/src/store/notification/__tests__/actions.test.ts
@@ -1,4 +1,4 @@
-import { notificationActions } from '..';
+import { notificationActions } from '../';
 import { NotificationTypes } from '../types';
 
 describe('Notification Actions', () => {

--- a/src/store/notification/__tests__/reducer.test.ts
+++ b/src/store/notification/__tests__/reducer.test.ts
@@ -1,6 +1,6 @@
+import { notificationActions } from '../';
 import notificationReducers from '../reducer';
 import { NotificationState } from '../types';
-import { notificationActions } from '..';
 
 describe('Notification Reducer', () => {
   const initialState: NotificationState = {

--- a/src/store/notification/__tests__/sagas.test.ts
+++ b/src/store/notification/__tests__/sagas.test.ts
@@ -1,11 +1,13 @@
+import { put, delay, select } from 'redux-saga/effects';
+
+import { ChannelID, pushNotification } from '@lib/push-notification';
+import appLocale from '@locales';
+import { animation } from '@styles';
+import * as utilIds from '@utils/id';
+
+import { notificationActions, notificationSelector } from '../';
 import * as sagas from '../sagas';
 import { NotificationTypes } from '../types';
-import { put, delay, select } from 'redux-saga/effects';
-import { notificationActions, notificationSelector } from '..';
-import { animation } from '@styles';
-import appLocale from '@locales';
-import { ChannelID, pushNotification } from '@lib/push-notification';
-import * as utilIds from '@utils/id';
 
 const strings = appLocale();
 

--- a/src/store/notification/__tests__/selectors.test.ts
+++ b/src/store/notification/__tests__/selectors.test.ts
@@ -1,6 +1,6 @@
 import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
 
-import { notificationSelector } from '..';
+import { notificationSelector } from '../';
 
 describe('Notification Selectors', () => {
   test('deve retornar o state corretamente', () => {

--- a/src/store/notification/actions.ts
+++ b/src/store/notification/actions.ts
@@ -2,6 +2,7 @@ import {
   PushNotificationScheduledLocalObject,
   PushNotificationScheduleObject,
 } from 'react-native-push-notification';
+
 import {
   NotificationTypes,
   NotificationAction,

--- a/src/store/notification/sagas.ts
+++ b/src/store/notification/sagas.ts
@@ -1,15 +1,17 @@
-import { BannerProps, NotificationTypes, NotificationAction } from './types';
-import { put, delay, takeLatest, select } from 'redux-saga/effects';
-import { notificationActions, notificationSelector } from '.';
-import { animation } from '@styles';
-import appLocale from '@locales';
 import {
   PushNotificationScheduledLocalObject,
   PushNotificationScheduleObject,
 } from 'react-native-push-notification';
-import { randomNumberId } from '@utils/id';
+import { put, delay, takeLatest, select } from 'redux-saga/effects';
+
 import { pushNotification } from '@lib/push-notification';
+import appLocale from '@locales';
+import { animation } from '@styles';
 import { syncTwoArraysByID } from '@utils/filters';
+import { randomNumberId } from '@utils/id';
+
+import { notificationActions, notificationSelector } from './';
+import { BannerProps, NotificationTypes, NotificationAction } from './types';
 
 const strings = appLocale();
 

--- a/src/store/product-list/__mocks__/productItemBuilder.mock.ts
+++ b/src/store/product-list/__mocks__/productItemBuilder.mock.ts
@@ -1,4 +1,5 @@
 import { PaperListData } from '@components/list';
+
 import { ProductItem } from '../types';
 
 export class ProductItemBuilderMock {

--- a/src/store/product-list/__mocks__/sagas.mock.ts
+++ b/src/store/product-list/__mocks__/sagas.mock.ts
@@ -1,6 +1,6 @@
 //@ts-nocheck
-import { ProductListBuilderMock } from './productListBuilder.mock';
 import { ProductItemBuilderMock } from './productItemBuilder.mock';
+import { ProductListBuilderMock } from './productListBuilder.mock';
 
 export const firstProductItem = () =>
   new ProductItemBuilderMock()

--- a/src/store/product-list/__tests__/actions.test.ts
+++ b/src/store/product-list/__tests__/actions.test.ts
@@ -1,7 +1,7 @@
-import { productListActions } from '..';
-import { ProductListTypes } from '../types';
-import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import { productListActions } from '../';
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import { ProductListTypes } from '../types';
 
 describe('ProductList Actions', () => {
   test('deve retornar setLoading corretamente.', () => {

--- a/src/store/product-list/__tests__/models.test.ts
+++ b/src/store/product-list/__tests__/models.test.ts
@@ -1,7 +1,8 @@
-import * as models from '../models';
 import * as firestore from '@react-native-firebase/firestore';
-import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import * as models from '../models';
 
 describe('ProductLists Models', () => {
   const docSet = jest.fn();

--- a/src/store/product-list/__tests__/reducer.test.ts
+++ b/src/store/product-list/__tests__/reducer.test.ts
@@ -1,8 +1,8 @@
 // @ts-nocheck
 
-import listItemsReducer from '../reducer';
-import { productListActions } from '..';
+import { productListActions } from '../';
 import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import listItemsReducer from '../reducer';
 
 describe('ProductList Reducers', () => {
   const initialState = {

--- a/src/store/product-list/__tests__/sagas-local.test.ts
+++ b/src/store/product-list/__tests__/sagas-local.test.ts
@@ -1,9 +1,10 @@
 import { select } from 'redux-saga/effects';
-import { productListSelectors } from '..';
-import * as sagaLocal from '../sagas-local';
-import { ProductItem, ProductList, ProductLists } from '../types';
+
+import { productListSelectors } from '../';
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
 import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import * as sagaLocal from '../sagas-local';
+import { ProductItem, ProductList, ProductLists } from '../types';
 
 describe('ProductList Sagas Local', () => {
   describe('Product Lists', () => {

--- a/src/store/product-list/__tests__/sagas-server.test.ts
+++ b/src/store/product-list/__tests__/sagas-server.test.ts
@@ -1,13 +1,14 @@
 // @ts-nocheck
+import { call, select } from 'redux-saga/effects';
 
 import { authSelectors } from '@store/auth';
 import { extractObjectElement } from '@utils/filters';
-import { call, select } from 'redux-saga/effects';
-import { productListModels } from '..';
-import * as sagaServer from '../sagas-server';
-import { appProductListFormater, dbProductListFormated } from '../utils';
+
+import { productListModels } from '../';
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
 import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import * as sagaServer from '../sagas-server';
+import { appProductListFormater, dbProductListFormated } from '../utils';
 
 describe('ProductList Sagas Server', () => {
   describe('Product Lists', () => {

--- a/src/store/product-list/__tests__/sagas.test.ts
+++ b/src/store/product-list/__tests__/sagas.test.ts
@@ -1,14 +1,16 @@
-import * as sagas from '../sagas';
-import { productListActions } from '..';
 import { put, call, select } from 'redux-saga/effects';
-import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
-import { ProductListActions, ProductList, ProductItem } from '../types';
-import * as sagaServer from '../sagas-server';
-import * as sagaLocal from '../sagas-local';
-import { injectProductListExtraData } from '../utils';
+
 import navigationService from '@navigator/services/navigationService';
+
+import { productListActions } from '../';
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import * as sagas from '../sagas';
+import * as sagaLocal from '../sagas-local';
+import * as sagaServer from '../sagas-server';
 import selectors from '../selectors';
+import { ProductListActions, ProductList, ProductItem } from '../types';
+import { injectProductListExtraData } from '../utils';
 
 jest.mock('@utils/id', () => ({
   generateUniqueID: jest.fn().mockReturnValue('123456789'),

--- a/src/store/product-list/__tests__/selectors.test.ts
+++ b/src/store/product-list/__tests__/selectors.test.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
-import { productListSelectors } from '..';
 import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
-import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+
+import { productListSelectors } from '../';
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
 
 describe('ProductList Selector', () => {
   test('deve obter o state do productListReducer', () => {

--- a/src/store/product-list/__tests__/utils.test.ts
+++ b/src/store/product-list/__tests__/utils.test.ts
@@ -1,14 +1,16 @@
 import firestore, {
   FirebaseFirestoreTypes,
 } from '@react-native-firebase/firestore';
-import DocumentFirestoreBuilder from 'src/firebase/__mocks__/documentFirestoreBuilder.mock';
-import QueryFirestoreBuilder from 'src/firebase/__mocks__/queryFirestoreBuilder.mock';
-import { ProductList } from '../types';
-import * as utils from '../utils';
-import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+
 import * as utilsDate from '@utils/date';
 import * as utilsID from '@utils/id';
+import DocumentFirestoreBuilder from 'src/firebase/__mocks__/documentFirestoreBuilder.mock';
+import QueryFirestoreBuilder from 'src/firebase/__mocks__/queryFirestoreBuilder.mock';
+
 import { ProductItemBuilderMock } from '../__mocks__/productItemBuilder.mock';
+import { ProductListBuilderMock } from '../__mocks__/productListBuilder.mock';
+import { ProductList } from '../types';
+import * as utils from '../utils';
 
 jest.mock('@react-native-firebase/firestore', () => ({
   Timestamp: {

--- a/src/store/product-list/index.ts
+++ b/src/store/product-list/index.ts
@@ -1,6 +1,6 @@
-import productListSelectors from './selectors';
 import productListActions from './actions';
 import * as models from './models';
+import productListSelectors from './selectors';
 
 const productListModels = { ...models };
 

--- a/src/store/product-list/models.ts
+++ b/src/store/product-list/models.ts
@@ -1,6 +1,7 @@
 import firestore, {
   FirebaseFirestoreTypes,
 } from '@react-native-firebase/firestore';
+
 import { ProductList, ProductItem } from './types';
 
 export type QueryFirestore<T> = FirebaseFirestoreTypes.QuerySnapshot<T>;

--- a/src/store/product-list/sagas-local.ts
+++ b/src/store/product-list/sagas-local.ts
@@ -1,12 +1,14 @@
-import { ProductList, ProductLists, ProductItem, ProductItems } from './types';
 import { select } from 'redux-saga/effects';
-import { productListSelectors } from '.';
+
+import { filterNotByID, filterByID } from '@utils/filters';
+
+import { productListSelectors } from './';
+import { ProductList, ProductLists, ProductItem, ProductItems } from './types';
 import {
   createProductItemArray,
   createProductListArray,
   updateProductListArray,
 } from './utils';
-import { filterNotByID, filterByID } from '@utils/filters';
 
 export function* createProductList(productList: ProductList) {
   const stateProductList: ProductLists = yield select(

--- a/src/store/product-list/sagas-server.ts
+++ b/src/store/product-list/sagas-server.ts
@@ -1,9 +1,11 @@
 import { select, call } from 'redux-saga/effects';
+
 import { authSelectors } from '@store/auth';
-import { ProductItem, ProductList, ProductLists } from './types';
 import { extractObjectElement } from '@utils/filters';
-import { productListModels } from '.';
+
+import { productListModels } from './';
 import { QueryFirestore } from './models';
+import { ProductItem, ProductList, ProductLists } from './types';
 import { appProductListFormater, dbProductListFormated } from './utils';
 
 export function* createProductList(productList: ProductList) {

--- a/src/store/product-list/sagas.ts
+++ b/src/store/product-list/sagas.ts
@@ -1,4 +1,14 @@
 import { takeLatest, put, call, select } from 'redux-saga/effects';
+
+import appLocale from '@locales';
+import navigationService from '@navigator/services/navigationService';
+import { notificationActions } from '@store/notification';
+import { addRemoveDays, formatDate } from '@utils/date';
+
+import { productListActions } from './';
+import * as sagaLocal from './sagas-local';
+import * as sagaServer from './sagas-server';
+import selectors from './selectors';
 import {
   ProductListTypes,
   ProductListActions,
@@ -6,15 +16,7 @@ import {
   ProductLists,
   ProductItem,
 } from './types';
-import { productListActions } from '.';
-import navigationService from '@navigator/services/navigationService';
 import { injectProductListExtraData } from './utils';
-import * as sagaServer from './sagas-server';
-import * as sagaLocal from './sagas-local';
-import { notificationActions } from '@store/notification';
-import appLocale from '@locales';
-import { addRemoveDays, formatDate } from '@utils/date';
-import selectors from './selectors';
 
 const strings = appLocale();
 

--- a/src/store/product-list/utils.ts
+++ b/src/store/product-list/utils.ts
@@ -1,9 +1,11 @@
+import { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
+
+import { injectTimeStamp } from '@utils/date';
+import { extractObjectElement, filterNotByID } from '@utils/filters';
+import { injectId } from '@utils/id';
+
 import { QueryFirestore, DocumentFirestore } from './models';
 import { ProductLists, ProductList, ProductItem } from './types';
-import { extractObjectElement, filterNotByID } from '@utils/filters';
-import { injectTimeStamp } from '@utils/date';
-import { injectId } from '@utils/id';
-import { FirebaseFirestoreTypes } from '@react-native-firebase/firestore';
 
 export const formatDocumentProductList = <T>(
   productList: DocumentFirestore<T>,

--- a/src/store/reducers.ts
+++ b/src/store/reducers.ts
@@ -1,10 +1,12 @@
 import { combineReducers } from 'redux';
-import generalReducer from './general/reducer';
-import productListReducer from '@store/product-list/reducer';
-import authReducer from './auth/reducer';
-import stockReducer from './stock/reducer';
-import notificationReducer from '@store/notification/reducer';
 import { PersistedState } from 'redux-persist';
+
+import notificationReducer from '@store/notification/reducer';
+import productListReducer from '@store/product-list/reducer';
+
+import authReducer from './auth/reducer';
+import generalReducer from './general/reducer';
+import stockReducer from './stock/reducer';
 
 const reducers = combineReducers({
   generalReducer,

--- a/src/store/root-sagas.ts
+++ b/src/store/root-sagas.ts
@@ -2,8 +2,8 @@ import { all } from 'redux-saga/effects';
 
 import authSagas from './auth/sagas';
 import notificationSagas from './notification/sagas';
-import stockSagas from './stock/sagas';
 import productListSagas from './product-list/sagas';
+import stockSagas from './stock/sagas';
 
 function* rootSagas() {
   yield all([...authSagas, ...notificationSagas, ...productListSagas, ...stockSagas]);

--- a/src/store/stock/__tests__/actions.test.ts
+++ b/src/store/stock/__tests__/actions.test.ts
@@ -1,5 +1,6 @@
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
-import { stockActions } from '..';
+
+import { stockActions } from '../';
 import { StockTypes } from '../types';
 
 describe('Stock Actions', () => {

--- a/src/store/stock/__tests__/models.test.ts
+++ b/src/store/stock/__tests__/models.test.ts
@@ -1,6 +1,8 @@
-import * as models from '../models';
 import * as firestore from '@react-native-firebase/firestore';
+
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+
+import * as models from '../models';
 
 describe('StockItems Models', () => {
   const docSet = jest.fn();

--- a/src/store/stock/__tests__/reducer.test.ts
+++ b/src/store/stock/__tests__/reducer.test.ts
@@ -1,8 +1,9 @@
 // @ts-nocheck
 
-import stockReducer from '../reducer';
-import { stockActions } from '..';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+
+import { stockActions } from '../';
+import stockReducer from '../reducer';
 
 describe('ProductList Reducers', () => {
   const initialState = {

--- a/src/store/stock/__tests__/sagas-local.test.ts
+++ b/src/store/stock/__tests__/sagas-local.test.ts
@@ -1,8 +1,10 @@
 import { select } from 'redux-saga/effects';
-import { stockSelectors } from '..';
-import * as sagaLocal from '../sagas-local';
-import { ProductItem, ProductItems } from '@store/product-list/types';
+
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { ProductItem, ProductItems } from '@store/product-list/types';
+
+import { stockSelectors } from '../';
+import * as sagaLocal from '../sagas-local';
 
 describe('Stock Sagas Local', () => {
   test('deve adicionar um novo item no array do stock e retornar o novo array', () => {

--- a/src/store/stock/__tests__/sagas-server.test.ts
+++ b/src/store/stock/__tests__/sagas-server.test.ts
@@ -1,10 +1,11 @@
 // @ts-nocheck
+import { call, select } from 'redux-saga/effects';
 
 import { authSelectors } from '@store/auth';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
 import { extractObjectElement } from '@utils/filters';
-import { call, select } from 'redux-saga/effects';
-import { stockModels } from '..';
+
+import { stockModels } from '../';
 import * as sagaServer from '../sagas-server';
 import { appStockItemsFormater, dbStockItemFormated } from '../utils';
 

--- a/src/store/stock/__tests__/sagas.test.ts
+++ b/src/store/stock/__tests__/sagas.test.ts
@@ -1,13 +1,15 @@
-import * as sagas from '../sagas';
-import { stockActions } from '..';
 import { put, call } from 'redux-saga/effects';
-import { StockActions } from '../types';
-import * as sagaServer from '../sagas-server';
-import * as sagaLocal from '../sagas-local';
-import { injectStockItemExtraData } from '../utils';
+
 import navigationService from '@navigator/services/navigationService';
-import { ProductItem } from '@store/product-list/types';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+import { ProductItem } from '@store/product-list/types';
+
+import { stockActions } from '../';
+import * as sagas from '../sagas';
+import * as sagaLocal from '../sagas-local';
+import * as sagaServer from '../sagas-server';
+import { StockActions } from '../types';
+import { injectStockItemExtraData } from '../utils';
 
 jest.mock('@utils/id', () => ({
   generateUniqueID: jest.fn().mockReturnValue('123456789'),

--- a/src/store/stock/__tests__/selectors.test.ts
+++ b/src/store/stock/__tests__/selectors.test.ts
@@ -1,6 +1,7 @@
-import { stockSelectors } from '..';
 import { AppStateMockBuilder } from '@store/__mocks__/AppStateMockBuilder.mock';
 import { ProductItemBuilderMock } from '@store/product-list/__mocks__/productItemBuilder.mock';
+
+import { stockSelectors } from '../';
 
 describe('Stock Selector', () => {
   test('deve obter o state do stockReducer', () => {

--- a/src/store/stock/actions.ts
+++ b/src/store/stock/actions.ts
@@ -1,4 +1,5 @@
 import { ProductItem, ProductItems } from '@store/product-list/types';
+
 import { StockActions, StockTypes } from './types';
 
 const actions = {

--- a/src/store/stock/index.ts
+++ b/src/store/stock/index.ts
@@ -1,6 +1,6 @@
 import actions from './actions';
-import * as stockSelectors from './selectors';
 import * as stockModels from './models';
+import * as stockSelectors from './selectors';
 
 const stockActions = actions;
 

--- a/src/store/stock/models.ts
+++ b/src/store/stock/models.ts
@@ -1,6 +1,7 @@
 import firestore, {
   FirebaseFirestoreTypes,
 } from '@react-native-firebase/firestore';
+
 import { ProductItem } from '@store/product-list/types';
 
 export type QueryFirestore = FirebaseFirestoreTypes.QuerySnapshot;

--- a/src/store/stock/sagas-local.ts
+++ b/src/store/stock/sagas-local.ts
@@ -1,8 +1,9 @@
 import { select } from 'redux-saga/effects';
-import { stockSelectors } from '.';
 
-import { filterNotByID } from '@utils/filters';
 import { ProductItem, ProductItems } from '@store/product-list/types';
+import { filterNotByID } from '@utils/filters';
+
+import { stockSelectors } from './';
 import { createStockItemArray, updateStockItemArray } from './utils';
 
 export function* createStockItem(stockItem: ProductItem) {

--- a/src/store/stock/sagas-server.ts
+++ b/src/store/stock/sagas-server.ts
@@ -1,9 +1,10 @@
 import { select, call } from 'redux-saga/effects';
-import { authSelectors } from '@store/auth';
 
-import { extractObjectElement } from '@utils/filters';
-import { stockModels } from '.';
+import { authSelectors } from '@store/auth';
 import { ProductItem } from '@store/product-list/types';
+import { extractObjectElement } from '@utils/filters';
+
+import { stockModels } from './';
 import { appStockItemsFormater } from './utils';
 
 export function* createStockItem(stockItem: ProductItem) {

--- a/src/store/stock/sagas.ts
+++ b/src/store/stock/sagas.ts
@@ -1,14 +1,16 @@
 import { takeLatest, put, call } from 'redux-saga/effects';
-import { StockTypes, StockActions } from './types';
-import { stockActions } from '.';
+
+import appLocale from '@locales';
 import navigationService from '@navigator/services/navigationService';
-import { injectStockItemExtraData } from './utils';
-import * as sagaServer from './sagas-server';
-import * as sagaLocal from './sagas-local';
+import { notificationActions } from '@store/notification';
 import { ProductItem } from '@store/product-list/types';
 import { addRemoveDays, formatDate } from '@utils/date';
-import { notificationActions } from '@store/notification';
-import appLocale from '@locales';
+
+import { stockActions } from './';
+import * as sagaLocal from './sagas-local';
+import * as sagaServer from './sagas-server';
+import { StockTypes, StockActions } from './types';
+import { injectStockItemExtraData } from './utils';
 
 const strings = appLocale();
 

--- a/src/store/stock/utils.ts
+++ b/src/store/stock/utils.ts
@@ -1,8 +1,9 @@
-import { QueryFirestore, DocumentFirestore } from './models';
-import { extractObjectElement, filterNotByID } from '@utils/filters';
-import { injectTimeStamp } from '@utils/date';
-import { injectId } from '@utils/id';
 import { ProductItem, ProductItems } from '@store/product-list/types';
+import { injectTimeStamp } from '@utils/date';
+import { extractObjectElement, filterNotByID } from '@utils/filters';
+import { injectId } from '@utils/id';
+
+import { QueryFirestore, DocumentFirestore } from './models';
 
 export const formatDocumentProductList = <T>(stockItems: DocumentFirestore) => {
   const productData = stockItems.data() as T;

--- a/src/store/types.ts
+++ b/src/store/types.ts
@@ -1,7 +1,7 @@
-import { ProductListState } from './product-list/types';
-import { GeneralState } from './general/types';
 import { AuthState } from './auth/types';
+import { GeneralState } from './general/types';
 import { NotificationState } from './notification/types';
+import { ProductListState } from './product-list/types';
 import { StockState } from './stock/types';
 
 export interface ApplicationState {

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,5 +1,5 @@
-import dimensions from './dimensions';
 import animation from './animation';
+import dimensions from './dimensions';
 import theme from './theme';
 
 const getStyleAsNumber = (pxElement: string) => {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,4 +1,5 @@
 import { DefaultTheme } from 'react-native-paper';
+
 import { Theme } from 'react-native-paper/src/types';
 
 interface CustomTheme extends Theme {

--- a/src/utils/__tests__/handleErrors.test.ts
+++ b/src/utils/__tests__/handleErrors.test.ts
@@ -1,7 +1,9 @@
-import * as reactRedux from 'react-redux';
 import { renderHook } from '@testing-library/react-hooks';
-import { useErrorMessage } from '@utils/handleErrors';
+import * as reactRedux from 'react-redux';
+
 import { notificationActions } from '@store/notification';
+import { useErrorMessage } from '@utils/handleErrors';
+
 describe('Testando handleErrors', () => {
   const dispatch = jest.fn();
   jest.spyOn(reactRedux, 'useDispatch').mockReturnValue(dispatch);

--- a/src/utils/handleErrors.ts
+++ b/src/utils/handleErrors.ts
@@ -1,4 +1,5 @@
 import { useDispatch } from 'react-redux';
+
 import { notificationActions } from '@store/notification';
 
 const useErrorMessage = (body: string) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3989,6 +3989,11 @@ eslint-plugin-flowtype@2.50.3:
   dependencies:
     lodash "^4.17.10"
 
+eslint-plugin-import-helpers@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-import-helpers/-/eslint-plugin-import-helpers-1.1.0.tgz#ab5c3f33de2a2f461061e8a13b143e8499c3baa0"
+  integrity sha512-a7l1Sj6hZybVHVkxVRVWm1WaAyk9yDjWvSVhUfnDR23i0vQ8RS1wv9k617qGIWPqkttzg299aEtx+bCHA2EoqQ==
+
 eslint-plugin-jest@22.4.1:
   version "22.4.1"
   resolved "https://registry.yarnpkg.com/eslint-plugin-jest/-/eslint-plugin-jest-22.4.1.tgz#a5fd6f7a2a41388d16f527073b778013c5189a9c"


### PR DESCRIPTION
Foi implementado o plugin [eslint-plugin-import-helpers](https://github.com/Tibfib/eslint-plugin-import-helpers) para organizar os imports por grupos, sendo estes separados por espaço, libs, alias, parents. E em cada um desses grupos está ordenado por ordem alfabética. Closes #68 