### PR TITLE
[#60] Ajustar layout do campo Data de Vencimento

### DIFF
--- a/src/components/helper-text/index.tsx
+++ b/src/components/helper-text/index.tsx
@@ -7,11 +7,10 @@ interface Props {
 }
 const HelperComponent = (props: Props) => {
   const { value, isError } = props;
-  if (!value) return null;
 
   const type = isError ? 'error' : 'info';
   
-  return <PaperHelperText type={type}>{value}</PaperHelperText>;
+  return <PaperHelperText type={type} visible={!!value}>{value}</PaperHelperText>;
 };
 
 export default HelperComponent;


### PR DESCRIPTION
Motivo: o componente HelperComponent retornava _null_ quando a prop _value_ não era fornecida.

O componente foi alterado para, ao invés de retornar _null_, este controle ser feito através da visibilidade do componente.

Closes #60 