### PR TITLE
[106]: Set app locale to system locale on first launch

### DIFF
--- a/__tests__/global.js
+++ b/__tests__/global.js
@@ -29,3 +29,7 @@ jest.mock('@react-native-community/async-storage', () => ({
 }));
 
 jest.mock('react-native-restart', () => ({ Restart: jest.fn() }));
+
+jest.mock('react-native-localize', () => ({
+  findBestAvailableLanguage: jest.fn(),
+}));

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "react-native-config": "^1.2.1",
     "react-native-gesture-handler": "^1.6.1",
     "react-native-iap": "^5.1.3",
+    "react-native-localize": "^2.0.1",
     "react-native-paper": "^4.2.0",
     "react-native-push-notification": "^6.1.1",
     "react-native-reanimated": "^1.8.0",

--- a/src/locales/__tests__/persist.test.ts
+++ b/src/locales/__tests__/persist.test.ts
@@ -12,18 +12,18 @@ describe('Locales - persist', () => {
 
   // should save the locale in AsyncStorage
   test('deve salvar no AsyncStorage o locale', async () => {
-    await saveLocale('enUS');
+    await saveLocale('en-US');
 
-    expect(spySetItem).toHaveBeenCalledWith(storeKey, 'enUS');
+    expect(spySetItem).toHaveBeenCalledWith(storeKey, 'en-US');
   });
 
   // should get the item from AsyncStorage
   test('deve obter o item do AsyncStorage', async () => {
-    spyGetItem.mockResolvedValue('ptBR');
+    spyGetItem.mockResolvedValue('pt-BR');
 
     const locale = await getLocale();
 
     expect(spyGetItem).toHaveBeenCalledWith(storeKey);
-    expect(locale).toEqual('ptBR');
+    expect(locale).toEqual('pt-BR');
   });
 });

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,24 +1,27 @@
 import i18n from 'i18n-js';
+import * as RNLocalize from 'react-native-localize';
 
 import * as persist from './persist';
 import { hasTranslationAvailable } from './utils';
 import enUS from './enUS'; // eslint-disable-line
 import ptBR from './ptBR'; // eslint-disable-line
 
-export type AppLocales = 'ptBR' | 'enUS';
+export type AppLocales = 'pt-BR' | 'en-US';
 
 i18n.translations = {
-  ptBR: { ...ptBR },
-  enUS: { ...enUS },
+  ['pt-BR']: { ...ptBR },
+  ['en-US']: { ...enUS },
 };
 
-i18n.defaultLocale = 'ptBR';
+i18n.defaultLocale = 'pt-BR';
 i18n.fallbacks = true;
 
 export const initLocale = async () => {
   const currentLocale = (await persist.getLocale()) as AppLocales;
   if (!currentLocale) {
-    i18n.locale = 'ptBR';
+    i18n.locale =
+      RNLocalize.findBestAvailableLanguage(Object.keys(i18n.translations))
+        ?.languageTag || 'pt-BR';
     return;
   }
 

--- a/src/routes/settings/__tests__/useLocales.test.ts
+++ b/src/routes/settings/__tests__/useLocales.test.ts
@@ -13,13 +13,13 @@ describe('Settings - useLocales', () => {
   const spyRestart = jest.spyOn(RNRestart, 'Restart');
   const spyAlert = jest.spyOn(Alert, 'alert');
   const spySetLanguage = jest.spyOn(locales, 'setLanguage');
-  jest.spyOn(locales, 'getAvailableLocales').mockReturnValue(['enUS', 'ptBR']);
-  jest.spyOn(locales, 'getLanguage').mockReturnValue('enUS');
+  jest.spyOn(locales, 'getAvailableLocales').mockReturnValue(['en-US', 'pt-BR']);
+  jest.spyOn(locales, 'getLanguage').mockReturnValue('en-US');
   jest
     .spyOn(locales, 'translateInLocale')
     .mockImplementation((path, language) => {
-      if (language === 'enUS') return 'English';
-      if (language === 'ptBR') return 'Português';
+      if (language === 'en-US') return 'English';
+      if (language === 'pt-BR') return 'Português';
 
       return '';
     });
@@ -36,11 +36,11 @@ describe('Settings - useLocales', () => {
     const { result } = renderHook(useLocales);
 
     expect(result.current.selectedLanguage).toEqual([
-      { id: 'enUS', title: 'English' },
+      { id: 'en-US', title: 'English' },
     ]);
     expect(result.current.languageList).toEqual([
-      { id: 'enUS', title: 'English' },
-      { id: 'ptBR', title: 'Português' },
+      { id: 'en-US', title: 'English' },
+      { id: 'pt-BR', title: 'Português' },
     ]);
   });
 
@@ -59,7 +59,7 @@ describe('Settings - useLocales', () => {
   test('ao setar o idioma, deve abrir um modal perguntado se deseja reiniciar, e deve setar o idioma escolhido ', async () => {
     const { result } = await renderHook(useLocales);
 
-    const selectedLanguage = [{ id: 'ptBR', title: 'Português' }];
+    const selectedLanguage = [{ id: 'pt-BR', title: 'Português' }];
 
     act(() => {
       result.current.handleSetLanguage(selectedLanguage);

--- a/yarn.lock
+++ b/yarn.lock
@@ -7782,6 +7782,11 @@ react-native-iphone-x-helper@^1.2.1:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.2.1.tgz#645e2ffbbb49e80844bb4cbbe34a126fda1e6772"
   integrity sha512-/VbpIEp8tSNNHIvstuA3Swx610whci1Zpc9mqNkqn14DkMbw+ORviln2u0XyHG1kPvvwTNGZY6QpeFwxYaSdbQ==
 
+react-native-localize@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/react-native-localize/-/react-native-localize-2.0.1.tgz#a5bf2f2910260ac2574d5ca5d5f95dc8bbc4ac1f"
+  integrity sha512-Tuf26iH7/pHd+yCAORD2EPLhkHdGTMEUXMiiKb4Pz69dE48R7C+MA30EqubE6qTlvAs6gHM+2E5dzLAxcGH5UA==
+
 react-native-paper@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/react-native-paper/-/react-native-paper-4.2.0.tgz#534c0f9dbeecfd73d20f1f7b1ef3df32aa2ca4b0"


### PR DESCRIPTION
Changes:

1. Add `react-native-localize` library
2. When app first launch, use the system locale to set app locale if supported by app
3. Write new tests
4. Update `enUs` to `en-US` and `ptBR` to `pt-BR` everywhere